### PR TITLE
chore: removed unused Artemis test dependency

### DIFF
--- a/target-definition/kura-networking.target
+++ b/target-definition/kura-networking.target
@@ -38,12 +38,6 @@
                     <version>2.0.0-SNAPSHOT</version>
                     <type>jar</type>
                 </dependency>
-                <dependency>
-                    <groupId>org.eclipse.kura</groupId>
-                    <artifactId>kura-artemis-bom</artifactId>
-                    <version>1.0.0-SNAPSHOT</version>
-                    <type>pom</type>
-                </dependency>
             </dependencies>
 
             <repositories>

--- a/tests/org.eclipse.kura.rest.network.configuration.provider.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.kura.rest.network.configuration.provider.test/META-INF/MANIFEST.MF
@@ -35,6 +35,5 @@ Import-Package: org.apache.commons.io;version="2.4.0",
  org.osgi.util.tracker;version="1.5.2",
  org.slf4j;version="1.7.25"
 Require-Bundle: org.eclipse.kura.rest.network.configuration.provider,
- org.eclipse.kura.http.server.manager,
- org.eclipse.kura.broker.artemis.core,
- org.eclipse.kura.broker.artemis.simple.mqtt
+ org.eclipse.kura.http.server.manager
+

--- a/tests/org.eclipse.kura.rest.network.status.provider.test/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.kura.rest.network.status.provider.test/META-INF/MANIFEST.MF
@@ -8,9 +8,7 @@ Bundle-License: Eclipse Public License v2.0
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.kura.rest.network.status.provider,
- org.eclipse.kura.http.server.manager,
- org.eclipse.kura.broker.artemis.core,
- org.eclipse.kura.broker.artemis.simple.mqtt
+ org.eclipse.kura.http.server.manager
 Import-Package: org.eclipse.kura;version="1.7.0",
  org.eclipse.kura.core.testutil.requesthandler,
  org.eclipse.kura.core.testutil.service;version="1.0.0",

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -184,38 +184,11 @@
                         uncomment for gogo shell, usage: telnet localhost 5002 
                         <appArgLine>-consoleLog -console 5002 -noExit</appArgLine>
                         -->
-                        
-                        <dependencies>
-                            <dependency>
-                                <type>p2-installable-unit</type>
-                                <artifactId>org.apache.activemq.artemis-mqtt-protocol</artifactId>
-                            </dependency>
-                        </dependencies>
                         <defaultStartLevel>
                             <level>4</level>
                             <autoStart>true</autoStart>
                         </defaultStartLevel>
                         <bundleStartLevel>
-                            <bundle>
-                                <id>org.eclipse.kura.broker.artemis.core</id>
-                                <level>4</level>
-                                <autoStart>true</autoStart>
-                            </bundle>
-                            <bundle>
-                                <id>org.eclipse.kura.broker.artemis.simple.mqtt</id>
-                                <level>4</level>
-                                <autoStart>true</autoStart>
-                            </bundle>
-                            <bundle>
-                                <id>org.eclipse.kura.broker.artemis.xml</id>
-                                <level>4</level>
-                                <autoStart>true</autoStart>
-                            </bundle>
-                            <bundle>
-                                <id>org.apache.activemq.artemis-mqtt-protocol</id>
-                                <level>4</level>
-                                <autoStart>true</autoStart>
-                            </bundle>
                             <bundle>
                                 <id>org.apache.logging.log4j.slf4j2.impl</id>
                                 <level>2</level>


### PR DESCRIPTION
This PR removes Artemis from the test dependencies, since no more needed.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
