### PR TITLE
test: fix coverage and test skip issues

### DIFF
--- a/bundles/org.eclipse.kura.network.threat.manager/pom.xml
+++ b/bundles/org.eclipse.kura.network.threat.manager/pom.xml
@@ -28,6 +28,6 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../../tests/org.eclipse.kura.network.threat.manager/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+		<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../../tests/org.eclipse.kura.network.threat.manager.test/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 </project>

--- a/tests/org.eclipse.kura.core.net.test/pom.xml
+++ b/tests/org.eclipse.kura.core.net.test/pom.xml
@@ -28,10 +28,6 @@
     <artifactId>org.eclipse.kura.core.net.test</artifactId>
     <packaging>eclipse-test-plugin</packaging>
 
-    <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/tests/org.eclipse.kura.linux.net.test/pom.xml
+++ b/tests/org.eclipse.kura.linux.net.test/pom.xml
@@ -51,7 +51,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <testSourceDirectory>${basedir}/src/test/java/</testSourceDirectory>
-                    <testClassesDirectory>${project.build.directory}/test-classes/</testClassesDirectory>
+                    <testClassesDirectory>${project.build.directory}/classes/</testClassesDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/tests/org.eclipse.kura.linux.net.test/pom.xml
+++ b/tests/org.eclipse.kura.linux.net.test/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>org.eclipse.kura.linux.net.test</artifactId>
     <packaging>eclipse-test-plugin</packaging>
 
-    <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/tests/org.eclipse.kura.net.admin.firewall.test/pom.xml
+++ b/tests/org.eclipse.kura.net.admin.firewall.test/pom.xml
@@ -26,10 +26,6 @@
     <artifactId>org.eclipse.kura.net.admin.firewall.test</artifactId>
     <packaging>eclipse-test-plugin</packaging>
 
-    <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-    </properties>
-
     <build>
         <plugins>
 			<plugin>

--- a/tests/org.eclipse.kura.net.configuration.test/pom.xml
+++ b/tests/org.eclipse.kura.net.configuration.test/pom.xml
@@ -26,10 +26,6 @@
     <artifactId>org.eclipse.kura.net.configuration.test</artifactId>
     <packaging>eclipse-test-plugin</packaging>
 
-    <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-    </properties>
-
     <build>
         <plugins>
 			<plugin>

--- a/tests/org.eclipse.kura.network.threat.manager.test/pom.xml
+++ b/tests/org.eclipse.kura.network.threat.manager.test/pom.xml
@@ -26,10 +26,6 @@
 	<artifactId>org.eclipse.kura.network.threat.manager.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
-	<properties>
-		<sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-	</properties>
-	
 	<build>
         <plugins>
 			<plugin>

--- a/tests/org.eclipse.kura.network.threat.manager.test/pom.xml
+++ b/tests/org.eclipse.kura.network.threat.manager.test/pom.xml
@@ -50,7 +50,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <testSourceDirectory>${basedir}/src/test/java/</testSourceDirectory>
-                    <testClassesDirectory>${project.build.directory}/test-classes/</testClassesDirectory>
+                    <testClassesDirectory>${project.build.directory}/classes/</testClassesDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/tests/org.eclipse.kura.nm.test/pom.xml
+++ b/tests/org.eclipse.kura.nm.test/pom.xml
@@ -26,10 +26,6 @@
     <artifactId>org.eclipse.kura.nm.test</artifactId>
     <packaging>eclipse-test-plugin</packaging>
 
-    <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.github.hypfvieh</groupId>

--- a/tests/org.eclipse.kura.rest.network.configuration.provider.test/pom.xml
+++ b/tests/org.eclipse.kura.rest.network.configuration.provider.test/pom.xml
@@ -27,10 +27,6 @@
     <artifactId>org.eclipse.kura.rest.network.configuration.provider.test</artifactId>
     <packaging>eclipse-test-plugin</packaging>
 
-    <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-    </properties>
     <build>
         <plugins>
             <plugin>

--- a/tests/org.eclipse.kura.rest.network.status.provider.test/pom.xml
+++ b/tests/org.eclipse.kura.rest.network.status.provider.test/pom.xml
@@ -27,9 +27,6 @@
     <artifactId>org.eclipse.kura.rest.network.status.provider.test</artifactId>
     <packaging>eclipse-test-plugin</packaging>
 
-    <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-    </properties>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Fix test coverage reported by Sonar.

A lot of tests were being skipped due to `maven-surefire-plugin` misconfiguration. Additionally I remove unnecessary `sonarXMLReportPaths` settings