### PR TITLE
feat: removed dnsmasq leases file during unistallation

### DIFF
--- a/distrib/src/main/resources/scripts/kura_network_uninstall.sh
+++ b/distrib/src/main/resources/scripts/kura_network_uninstall.sh
@@ -87,17 +87,14 @@ recover_dnsmasq_conf_file() {
 }
 
 remove_dnsmasq_leases() {
+    # Remove dnsmasq leases file if it exists and is owned by 'kurad'
     DNSMASQ_LEASES_FILE="/var/lib/dhcp/dnsmasq.leases"
     if [ -f "${DNSMASQ_LEASES_FILE}" ]; then
-        # Check if the file owner is kur before removing
         FILE_OWNER=$(stat -c '%U' "${DNSMASQ_LEASES_FILE}" 2>/dev/null)
         if [ "${FILE_OWNER}" = "kurad" ]; then
             rm -f "${DNSMASQ_LEASES_FILE}"
-        else
-            echo "Warning: ${DNSMASQ_LEASES_FILE} owner is '${FILE_OWNER}', not 'kurad'. Skipping removal."
+            echo "The dnsmasq leases file has been successfully removed."
         fi
-    else  
-        echo "Warning: ${DNSMASQ_LEASES_FILE} does not exist."
     fi
 }
 

--- a/distrib/src/main/resources/scripts/kura_network_uninstall.sh
+++ b/distrib/src/main/resources/scripts/kura_network_uninstall.sh
@@ -86,6 +86,21 @@ recover_dnsmasq_conf_file() {
     fi
 }
 
+remove_dnsmasq_leases() {
+    DNSMASQ_LEASES_FILE="/var/lib/dhcp/dnsmasq.leases"
+    if [ -f "${DNSMASQ_LEASES_FILE}" ]; then
+        # Check if the file owner is kur before removing
+        FILE_OWNER=$(stat -c '%U' "${DNSMASQ_LEASES_FILE}" 2>/dev/null)
+        if [ "${FILE_OWNER}" = "kurad" ]; then
+            rm -f "${DNSMASQ_LEASES_FILE}"
+        else
+            echo "Warning: ${DNSMASQ_LEASES_FILE} owner is '${FILE_OWNER}', not 'kurad'. Skipping removal."
+        fi
+    else  
+        echo "Warning: ${DNSMASQ_LEASES_FILE} does not exist."
+    fi
+}
+
 recover_web_ui_kura_properties() {
     if [ -f "${BASE_DIR}/${KURA_SYMLINK}/framework/kura.properties" ]; then
         sed -i "s|^kura.have.net.admin=.*|kura.have.net.admin=false|" "${BASE_DIR}/${KURA_SYMLINK}/framework/kura.properties"
@@ -126,5 +141,7 @@ run_kura_networking_uninstall() {
 }
 
 run_kura_networking_uninstall
+
+remove_dnsmasq_leases
 
 exit 0

--- a/distrib/src/main/resources/scripts/kura_network_uninstall.sh
+++ b/distrib/src/main/resources/scripts/kura_network_uninstall.sh
@@ -120,6 +120,7 @@ kura_uninstall() {
         bash "${BASE_DIR}/${KURA_SYMLINK}/.data/manage_network_permissions.sh" -u
         restore_nm_installation
         recover_dnsmasq_conf_file
+        remove_dnsmasq_leases
 
         recover_web_ui_kura_properties
         remove_kura_networking_service
@@ -138,7 +139,5 @@ run_kura_networking_uninstall() {
 }
 
 run_kura_networking_uninstall
-
-remove_dnsmasq_leases
 
 exit 0


### PR DESCRIPTION
When an interface is configured as a **DHCP Server** and **dnsmasq** is the active service, a `dnsmasq.leases` file is created under `/var/lib/dhcp/`.

When **Kura** is later uninstalled, this file is **not removed** and may cause errors if other services try to interact with it, since `kurad` is the owner of the leases file.

This PR introduces the **removal of this file during Kura uninstallation** to prevent errors after Kura is removed.
