### PR TITLE
fix: Fixed missing ipv6 filter rules when flooding protection is enabled

### DIFF
--- a/bundles/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
+++ b/bundles/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
@@ -41,7 +41,7 @@ public class FloodingProtectionOptions {
             "-A prerouting-kura -p tcp --tcp-flags ALL FIN,PSH,URG -j DROP",
             "-A prerouting-kura -p tcp --tcp-flags ALL SYN,FIN,PSH,URG -j DROP",
             "-A prerouting-kura -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j DROP",
-            "-A prerouting-kura -p icmp -m icmp --icmp-type 8 -m state --state NEW,RELATED,ESTABLISHED -j DROP", 
+            "-A prerouting-kura -p icmp -m icmp --icmp-type 8 -m state --state NEW,RELATED,ESTABLISHED -j DROP",
             "-A prerouting-kura -f -j DROP" };
 
     private static final String[] FLOODING_PROTECTION_MANGLE_RULES_IPV6 = {
@@ -69,6 +69,49 @@ public class FloodingProtectionOptions {
             "-A prerouting-kura -m ipv6header --header esp --soft -j DROP",
             "-A prerouting-kura -m ipv6header --header none --soft -j DROP",
             "-A prerouting-kura -m rt --rt-type 0 -j DROP", "-A output-kura -m rt --rt-type 0 -j DROP" };
+
+    private static final String[] FLOODING_PROTECTION_FILTER_RULES_IPV6 = {
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 1 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 2 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 3/0 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 3/1 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/0 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/1 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/2 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 128 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 129 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 144 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 145 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 146 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 147 -j ACCEPT",
+            // Multicast Listener Discovery - essential for IPv6 multicast (mDNS, DHCPv6, etc.)
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 130 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 131 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 132 -j ACCEPT",
+            // Critical Neighbor/Router Discovery - no source restriction for IPv6 connectivity
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 133 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 134 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 135 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 136 -j ACCEPT",
+            "-A input-kura -s fe80::/10 -p ipv6-icmp -m ipv6-icmp --icmpv6-type 141 -j ACCEPT",
+            "-A input-kura -s fe80::/10 -p ipv6-icmp -m ipv6-icmp --icmpv6-type 142 -j ACCEPT",
+            "-A input-kura -s fe80::/10 -p ipv6-icmp -m ipv6-icmp --icmpv6-type 148 -j ACCEPT",
+            "-A input-kura -s fe80::/10 -p ipv6-icmp -m ipv6-icmp --icmpv6-type 149 -j ACCEPT",
+            // Multicast Router Discovery - essential for IPv6 routing protocols
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 151 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 152 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 153 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 1 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 2 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 3/0 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 3/1 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/0 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/1 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/2 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 144 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 145 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 146 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 147 -j ACCEPT" };
 
     private static final String FRAG_LOW_THR_IPV4_NAME = "/proc/sys/net/ipv4/ipfrag_low_thresh";
     private static final String FRAG_HIGH_THR_IPV4_NAME = "/proc/sys/net/ipv4/ipfrag_high_thresh";
@@ -132,7 +175,11 @@ public class FloodingProtectionOptions {
     }
 
     public Set<String> getFloodingProtectionFilterRulesIPv6() {
-        return new LinkedHashSet<>();
+        if (isIPv6Enabled()) {
+            return new LinkedHashSet<>(Arrays.asList(FLOODING_PROTECTION_FILTER_RULES_IPV6));
+        } else {
+            return new LinkedHashSet<>();
+        }
     }
 
     public Set<String> getFloodingProtectionNatRulesIPv6() {

--- a/tests/org.eclipse.kura.network.threat.manager.test/src/test/java/org/eclipse/kura/network/threat/manager/FloodingProtectionConfiguratorTest.java
+++ b/tests/org.eclipse.kura.network.threat.manager.test/src/test/java/org/eclipse/kura/network/threat/manager/FloodingProtectionConfiguratorTest.java
@@ -87,6 +87,46 @@ public class FloodingProtectionConfiguratorTest {
             "-A prerouting-kura -m ipv6header --header none --soft -j DROP",
             "-A prerouting-kura -m rt --rt-type 0 -j DROP", "-A output-kura -m rt --rt-type 0 -j DROP" };
 
+    private static final String[] FLOODING_PROTECTION_FILTER_RULES_IPV6 = {
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 1 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 2 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 3/0 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 3/1 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/0 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/1 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/2 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 128 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 129 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 144 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 145 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 146 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 147 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 130 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 131 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 132 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 133 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 134 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 135 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 136 -j ACCEPT",
+            "-A input-kura -s fe80::/10 -p ipv6-icmp -m ipv6-icmp --icmpv6-type 141 -j ACCEPT",
+            "-A input-kura -s fe80::/10 -p ipv6-icmp -m ipv6-icmp --icmpv6-type 142 -j ACCEPT",
+            "-A input-kura -s fe80::/10 -p ipv6-icmp -m ipv6-icmp --icmpv6-type 148 -j ACCEPT",
+            "-A input-kura -s fe80::/10 -p ipv6-icmp -m ipv6-icmp --icmpv6-type 149 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 151 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 152 -j ACCEPT",
+            "-A input-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 153 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 1 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 2 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 3/0 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 3/1 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/0 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/1 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 4/2 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 144 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 145 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 146 -j ACCEPT",
+            "-A forward-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 147 -j ACCEPT" };
+
     private static final String FRAG_LOW_THR_IPV4_NAME = "/tmp/ipfrag_low_thresh";
     private static final String FRAG_HIGH_THR_IPV4_NAME = "/tmp/ipfrag_high_thresh";
     private static final String FRAG_LOW_THR_IPV6_NAME = "/tmp/nf_conntrack_frag6_low_thresh";
@@ -128,7 +168,7 @@ public class FloodingProtectionConfiguratorTest {
         whenFloodingProtectionConfiguratorIsActivated(true, true);
         whenFirewallFilterRulesIPv6AreRetrieved();
 
-        thenFirewallRulesAre(new HashSet<String>());
+        thenFirewallRulesAre(new HashSet<String>(Arrays.asList(FLOODING_PROTECTION_FILTER_RULES_IPV6)));
     }
 
     @Test
@@ -205,8 +245,8 @@ public class FloodingProtectionConfiguratorTest {
 
         whenFloodingProtectionConfiguratorIsActivated(true, true);
 
-        thenFirewallRulesIPv6AreApplied(new HashSet<>(), new HashSet<>(),
-                new HashSet<>(Arrays.asList(FLOODING_PROTECTION_MANGLE_RULES_IPV6)));
+        thenFirewallRulesIPv6AreApplied(new HashSet<>(Arrays.asList(FLOODING_PROTECTION_FILTER_RULES_IPV6)),
+                new HashSet<>(), new HashSet<>(Arrays.asList(FLOODING_PROTECTION_MANGLE_RULES_IPV6)));
     }
 
     @Test


### PR DESCRIPTION
Tested on raspberry pi

```
PING google.com(mil07s19-in-x0e.1e100.net (2a00:1450:4002:416::200e)) 56 data bytes
64 bytes from mil07s19-in-x0e.1e100.net (2a00:1450:4002:416::200e): icmp_seq=1 ttl=117 time=61.4 ms
64 bytes from mil07s19-in-x0e.1e100.net (2a00:1450:4002:416::200e): icmp_seq=2 ttl=117 time=60.6 ms
64 bytes from mil07s19-in-x0e.1e100.net (2a00:1450:4002:416::200e): icmp_seq=3 ttl=117 time=60.4 ms
64 bytes from mil07s19-in-x0e.1e100.net (2a00:1450:4002:416::200e): icmp_seq=4 ttl=117 time=60.9 ms
64 bytes from mil07s19-in-x0e.1e100.net (2a00:1450:4002:416::200e): icmp_seq=5 ttl=117 time=60.6 ms
^C
--- google.com ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 4009ms
rtt min/avg/max/mdev = 60.435/60.792/61.363/0.330 ms
root@raspberrypi:~# ping github.com
PING github.com (140.82.121.4) 56(84) bytes of data.
64 bytes from lb-140-82-121-4-fra.github.com (140.82.121.4): icmp_seq=1 ttl=48 time=23.8 ms
64 bytes from lb-140-82-121-4-fra.github.com (140.82.121.4): icmp_seq=2 ttl=48 time=23.8 ms
^C
--- github.com ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 5031ms
rtt min/avg/max/mdev = 23.755/23.799/23.844/0.044 ms
root@raspberrypi:~# ping github.com
PING github.com (140.82.121.4) 56(84) bytes of data.
64 bytes from lb-140-82-121-4-fra.github.com (140.82.121.4): icmp_seq=1 ttl=48 time=24.0 ms
64 bytes from lb-140-82-121-4-fra.github.com (140.82.121.4): icmp_seq=2 ttl=48 time=25.6 ms
64 bytes from lb-140-82-121-4-fra.github.com (140.82.121.4): icmp_seq=3 ttl=48 time=24.2 ms
^C
--- github.com ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2004ms
rtt min/avg/max/mdev = 24.033/24.610/25.638/0.728 ms
root@raspberrypi:~# ping6 google.com
PING google.com(mil07s19-in-x0e.1e100.net (2a00:1450:4002:416::200e)) 56 data bytes
64 bytes from mil07s19-in-x0e.1e100.net (2a00:1450:4002:416::200e): icmp_seq=1 ttl=117 time=60.5 ms
64 bytes from mil07s19-in-x0e.1e100.net (2a00:1450:4002:416::200e): icmp_seq=2 ttl=117 time=60.7 ms
^C
--- google.com ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1000ms
rtt min/avg/max/mdev = 60.537/60.605/60.674/0.068 ms
```
