### PR TITLE
feat(nm): Dropped DHCPv6 method

### DIFF
--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraIp6ConfigurationMethod.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraIp6ConfigurationMethod.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,18 +13,23 @@
 
 package org.eclipse.kura.nm;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public enum KuraIp6ConfigurationMethod {
 
     AUTO,
-    DHCP,
     MANUAL;
 
+    private static final Logger logger = LoggerFactory.getLogger(KuraIp6ConfigurationMethod.class);
+    
     public static KuraIp6ConfigurationMethod fromString(String status) {
         switch (status) {
         case "netIPv6MethodAuto":
             return KuraIp6ConfigurationMethod.AUTO;
         case "netIPv6MethodDhcp":
-            return KuraIp6ConfigurationMethod.DHCP;
+            logger.warn("DHCP IPv6 configuration method is deprecated. Using AUTO method instead.");
+            return KuraIp6ConfigurationMethod.AUTO;
         case "netIPv6MethodManual":
             return KuraIp6ConfigurationMethod.MANUAL;
         default:

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -353,15 +353,9 @@ public class NMSettingsConverter {
         KuraIp6ConfigurationMethod ip6ConfigMethod = getIp6ConfigMethod(props, deviceId);
 
         if (ip6ConfigMethod.equals(KuraIp6ConfigurationMethod.AUTO)) {
-
             configureIp6MethodAuto(props, deviceId, settings);
 
-        } else if (ip6ConfigMethod.equals(KuraIp6ConfigurationMethod.DHCP)) {
-
-            settings.put(NM_SETTINGS_IPV6_METHOD, new Variant<>("dhcp"));
-
         } else if (ip6ConfigMethod.equals(KuraIp6ConfigurationMethod.MANUAL)) {
-
             configureIp6MethodManual(props, deviceId, ip6Status, settings);
 
         } else {

--- a/target-definition/kura-networking.target
+++ b/target-definition/kura-networking.target
@@ -13,7 +13,8 @@
     Contributors:
      Eurotech
 
---><target name="kura-networking Target Definition" sequenceNumber="75">
+-->
+<target name="kura-networking Target Definition" sequenceNumber="75">
     <locations>
         <location includeDependencyDepth="direct" includeDependencyScopes="compile,test" missingManifest="ignore" type="Maven">
 

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -442,7 +442,7 @@ public class NMSettingsConverterTest {
     }
 
     @Test
-    public void buildIpv6SettingsShouldWorkWhenGivenExpectedMapWithDhcpEnableAndWAN() {
+    public void buildIpv6SettingsShouldSetAutoWhenGivenExpectedMapWithDhcpEnableAndWAN() {
         givenMapWith("net.interface.wlan0.config.ip6.address.method", "netIPv6MethodDhcp");
         givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusEnabledWAN");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
@@ -450,7 +450,7 @@ public class NMSettingsConverterTest {
         whenBuildIpv6SettingsIsRunWith(this.networkProperties, "wlan0", this.nmVersion);
 
         thenNoExceptionOccurred();
-        thenResultingMapContains("method", "dhcp");
+        thenResultingMapContains("method", "auto");
     }
 
     @Test


### PR DESCRIPTION
This pull request removes support for the deprecated IPv6 DHCP configuration method and ensures that any attempt to use it will now default to the AUTO method. The changes also update related logic and tests to reflect this deprecation and cleanup.

**Deprecation and removal of IPv6 DHCP method:**

* The `KuraIp6ConfigurationMethod` enum no longer includes the `DHCP` value. Any input requesting the DHCP method will now log a warning and use `AUTO` instead.
* The logic in `NMSettingsConverter.java` that previously handled the DHCP method has been removed; only AUTO and MANUAL methods are now supported for IPv6 configuration.

**Test updates:**

* The test for IPv6 DHCP configuration in `NMSettingsConverterTest.java` has been updated to expect the AUTO method instead of DHCP, ensuring test coverage matches the new behavior.

**Other minor changes:**

* Copyright years updated in `KuraIp6ConfigurationMethod.java`.
* Minor XML formatting fix in `kura-networking.target`.