### PR TITLE
ci: Added tests folder to exclusions

### DIFF
--- a/.jenkins/ci.groovy
+++ b/.jenkins/ci.groovy
@@ -7,7 +7,7 @@ node {
             enable: true,
             projectKey: "eclipse-kura_kura-networking",
             tokenId: "sonarcloud-token-kura-networking",
-            exclusions: "**/*.xml,**/*.yml,bundles/org.eclipse.kura.nm/src/main/java/org/freedesktop/**/*,bundles/org.eclipse.kura.nm/src/main/java/fi/w1/**/*",
+            exclusions: "tests/**/*,**/*.xml,**/*.yml,bundles/org.eclipse.kura.nm/src/main/java/org/freedesktop/**/*,bundles/org.eclipse.kura.nm/src/main/java/fi/w1/**/*",
             testExclusions: "**/*"
         ],
     )


### PR DESCRIPTION
This pull request makes a small update to the SonarCloud configuration in the Jenkins CI pipeline. Specifically, it expands the list of excluded files from analysis to also include everything under the `tests` directory.

- SonarCloud configuration in `.jenkins/ci.groovy` now excludes all files in the `tests` directory from analysis by adding `tests/**/*` to the `exclusions` list.