### PR TITLE
feat(nm): prevent unnecessary network configuration updates

### DIFF
--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -587,41 +587,47 @@ public class NMDbusConnector {
         Optional<Connection> connection = this.networkManager.getAssociatedConnection(device);
         Map<String, Map<String, Variant<?>>> newConnectionSettings = NMSettingsConverter.buildSettings(properties,
                 connection, deviceId, interfaceName, deviceType, this.networkManager.getVersion());
-        
-        Map<String, Map<String, Variant<?>>> oldConnectionSettings = connection.isPresent() ? connection.get().GetSettings() : null;
-        
-        // Debug: print settings (remove in production)
-        logger.info("New connection settings for device {}: {}", deviceId, newConnectionSettings);
-        logger.info("Old connection settings for device {}: {}", deviceId, oldConnectionSettings);
-        logger.info("Settings equal: {}", NMSettingsComparator.areSettingsEqual(newConnectionSettings, oldConnectionSettings));
-        // End Debug
-        
-        if (Objects.isNull(oldConnectionSettings)
-                || !NMSettingsComparator.areSettingsEqual(newConnectionSettings, oldConnectionSettings)) {
 
-            DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),
+        DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),
                 NMDeviceState.NM_DEVICE_STATE_CONFIG, this.timeout);
 
-            if (connection.isPresent()) {
-                connection.get().Update(newConnectionSettings);
+        boolean skipActivation = false;
+        if (connection.isPresent()) {
+            // Compare old and new settings. Given that NetworkManager may remove paramters from the settings
+            // (e.g., removing 802.1x settings when not used), we need NM to pre-ingest the new settings
+            Map<String, Map<String, Variant<?>>> oldConnectionSettings = connection.get().GetSettings();
+            // Map<String, Map<String, Variant<?>>> oldConnectionSecrets = connection.get().GetSecrets();
+            connection.get().UpdateUnsaved(newConnectionSettings);
+            Map<String, Map<String, Variant<?>>> cmpConnectionSettings = connection.get().GetSettings();
+            // Map<String, Map<String, Variant<?>>> cmpConnectionSecrets = connection.get().GetSecrets();
+            
+            // TODO: Set these in debug
+            logger.info("New connection settings for device {}: {}", deviceId, cmpConnectionSettings);
+            logger.info("Old connection settings for device {}: {}", deviceId, oldConnectionSettings);
+
+            if (NMSettingsComparator.areSettingsEqual(cmpConnectionSettings, oldConnectionSettings)) {
+                logger.info("No changes in connection settings for device {}", deviceId);
+                skipActivation = true;
             } else {
-                Settings settings = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_SETTINGS_BUS_PATH, Settings.class);
-                DBusPath createdConnectionPath = settings.AddConnection(newConnectionSettings);
-                Connection createdConnection = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
-                        createdConnectionPath.getPath(), Connection.class);
-                connection = Optional.of(createdConnection);
+                logger.info("Updated connection settings for device {}", deviceId);
+                connection.get().Save();
             }
 
+        } else {
+            Settings settings = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_SETTINGS_BUS_PATH, Settings.class);
+            DBusPath createdConnectionPath = settings.AddConnection(newConnectionSettings);
+            Connection createdConnection = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
+                    createdConnectionPath.getPath(), Connection.class);
+            connection = Optional.of(createdConnection);
+        }
+
+        if (!skipActivation) {
             try {
                 this.networkManager.activateConnection(connection.get(), device);
                 dsLock.waitForSignal();
             } catch (DBusExecutionException e) {
                 logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
             }
-
-        } else {
-            logger.info("No changes detected in connection settings for device {}. Skipping update and activation.",
-                    deviceId);
         }
 
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -37,6 +37,7 @@ import org.eclipse.kura.net.status.NetworkInterfaceStatus;
 import org.eclipse.kura.net.wifi.WifiChannel;
 import org.eclipse.kura.net.wifi.WifiMode;
 import org.eclipse.kura.net.wifi.WifiSecurity;
+import org.eclipse.kura.nm.configuration.NMSettingsComparator;
 import org.eclipse.kura.nm.configuration.NMSettingsConverter;
 import org.eclipse.kura.nm.enums.MMModemLocationSource;
 import org.eclipse.kura.nm.enums.MMModemState;
@@ -586,6 +587,14 @@ public class NMDbusConnector {
         Optional<Connection> connection = this.networkManager.getAssociatedConnection(device);
         Map<String, Map<String, Variant<?>>> newConnectionSettings = NMSettingsConverter.buildSettings(properties,
                 connection, deviceId, interfaceName, deviceType, this.networkManager.getVersion());
+        
+        Map<String, Map<String, Variant<?>>> oldConnectionSettings = connection.isPresent() ? connection.get().GetSettings() : null;
+        if (Objects.nonNull(oldConnectionSettings)
+                && NMSettingsComparator.areSettingsEqual(newConnectionSettings, oldConnectionSettings)) {
+            logger.info("No changes detected in connection settings for device {}. Skipping update and activation.",
+                    deviceId);
+            return;
+        }
 
         DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),
                 NMDeviceState.NM_DEVICE_STATE_CONFIG, this.timeout);

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -599,8 +599,9 @@ public class NMDbusConnector {
 
         boolean skipActivation = false;
         if (connection.isPresent()) {
-            // Compare old and new settings. Given that NetworkManager may remove paramters from the settings
-            // (e.g., removing 802.1x settings when not used), we need NM to pre-ingest the new settings
+            // Compare old and new settings. Given that NetworkManager may remove parameters
+            // from the settings if they are set to the default value (e.g., removing mtu
+            // settings when set to the default value), we need NM to pre-ingest the new settings
             Map<String, Map<String, Variant<?>>> oldConnectionSettings = getAllSettings(connection.get(), deviceType);
             connection.get().UpdateUnsaved(newConnectionSettings);
             Map<String, Map<String, Variant<?>>> cmpConnectionSettings = getAllSettings(connection.get(), deviceType);

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -656,10 +656,13 @@ public class NMDbusConnector {
         Map<String, Map<String, Variant<?>>> allSettings = new HashMap<>();
         allSettings.putAll(connection.GetSettings());
 
-        // Note: when adding a new devie type among the supported ones (i.e.
-        // CONFIGURATION_SUPPORTED_DEVICE_TYPES) make sure to add the related settings
-        // keys here in order to properly retrieve secrets for comparison in
-        // enableInterface method
+        // Note: when adding a new device type among the supported ones make sure to add
+        // the related settings keys here in order to properly retrieve secrets for
+        // comparison in enableInterface method
+        if(!CONFIGURATION_SUPPORTED_DEVICE_TYPES.contains(deviceType)) {
+            throw new IllegalArgumentException(
+                    String.format("Device type %s not supported for secret settings retrieval", deviceType));
+        }
         String[] settingKeys;
         if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_WIFI)) {
             settingKeys = new String[] {"802-11-wireless", "802-11-wireless-security", "802-1x"};

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -597,7 +597,6 @@ public class NMDbusConnector {
         DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),
                 NMDeviceState.NM_DEVICE_STATE_CONFIG, this.timeout);
 
-        boolean skipActivation = false;
         if (connection.isPresent()) {
             // Compare old and new settings. Given that NetworkManager may remove parameters
             // from the settings if they are set to the default value (e.g., removing mtu
@@ -613,7 +612,6 @@ public class NMDbusConnector {
 
             if (NMSettingsComparator.areSettingsEqual(cmpConnectionSettings, oldConnectionSettings) ) {
                 logger.info("No changes in connection settings for device {}", deviceId);
-                skipActivation = true;
             } else {
                 logger.info("Updated connection settings for device {}", deviceId);
                 connection.get().Save();
@@ -626,13 +624,13 @@ public class NMDbusConnector {
                     createdConnectionPath.getPath(), Connection.class);
             connection = Optional.of(createdConnection);
         }
-      
+
         // Reapply settings anyway to let NM reconfigure the device if needed (e.g. Modem connection failures)
         boolean isReapplySuccessful = this.networkManager.reapplySettings(device, newConnectionSettings);
 
-        if (!skipActivation || !isReapplySuccessful) {
+        if (!isReapplySuccessful) {
             try {
-                logger.info("Activating connection for device {}", deviceId);
+                logger.info("Reapply failed. Activating connection for device {}", deviceId);
                 this.networkManager.activateConnection(connection.get(), device);
                 dsLock.waitForSignal();
             } catch (DBusExecutionException e) {

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -672,7 +672,6 @@ public class NMDbusConnector {
         for (String settingKey : settingKeys) {
             try {
                 Map<String, Map<String, Variant<?>>> secrets = connection.GetSecrets(settingKey);
-                // Merge the secrets into the allSettings map
                 allSettings.put(settingKey, secrets.get(settingKey));
             } catch (DBusExecutionException e) {
                 // Ignore exception, it means that there are no secrets for this setting, which is fine

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -572,7 +572,12 @@ public class NMDbusConnector {
     private void enableInterface(String deviceId, NetworkProperties properties, Optional<Device> device,
             NMDeviceType deviceType) throws DBusException {
         if (device.isPresent()) {
+            long start;
+            long stop;
+            start = System.currentTimeMillis();
             enableInterface(deviceId, properties, device.get(), deviceType);
+            stop = System.currentTimeMillis();
+            logger.info("Enabling interface {} took {} ms", deviceId, (stop - start));
         } else {
             createVirtualInterface(deviceId, properties, deviceType);
         }
@@ -596,9 +601,9 @@ public class NMDbusConnector {
         if (connection.isPresent()) {
             // Compare old and new settings. Given that NetworkManager may remove paramters from the settings
             // (e.g., removing 802.1x settings when not used), we need NM to pre-ingest the new settings
-            Map<String, Map<String, Variant<?>>> oldConnectionSettings = getAllSettings(connection.get());
+            Map<String, Map<String, Variant<?>>> oldConnectionSettings = getAllSettings(connection.get(), deviceType);
             connection.get().UpdateUnsaved(newConnectionSettings);
-            Map<String, Map<String, Variant<?>>> cmpConnectionSettings = getAllSettings(connection.get());
+            Map<String, Map<String, Variant<?>>> cmpConnectionSettings = getAllSettings(connection.get(), deviceType);
 
             // TODO: Set these in debug
             logger.info("New connection settings for device {}: {}", deviceId, cmpConnectionSettings);
@@ -647,11 +652,19 @@ public class NMDbusConnector {
 
     }
 
-    private Map<String, Map<String, Variant<?>>> getAllSettings(Connection connection) {
+    private Map<String, Map<String, Variant<?>>> getAllSettings(Connection connection, NMDeviceType deviceType) {
         Map<String, Map<String, Variant<?>>> allSettings = new HashMap<>();
         allSettings.putAll(connection.GetSettings());
 
-        String[] settingKeys = {"802-11-wireless-security", "802-1x", "gsm", "cdma", "ppp"};
+        String[] settingKeys;
+        if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_WIFI)) {
+            settingKeys = new String[] {"802-11-wireless", "802-11-wireless-security", "802-1x"};
+        } else if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_MODEM)) {
+            settingKeys = new String[] {"gsm", "cdma", "ppp"};
+        } else {
+            settingKeys = new String[]{};
+        }
+
         for (String settingKey : settingKeys) {
             try {
                 Map<String, Map<String, Variant<?>>> secrets = connection.GetSecrets(settingKey);

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -632,6 +632,7 @@ public class NMDbusConnector {
 
         if (!skipActivation || !isReapplySuccessful) {
             try {
+                logger.info("Activating connection for device {}", deviceId);
                 this.networkManager.activateConnection(connection.get(), device);
                 dsLock.waitForSignal();
             } catch (DBusExecutionException e) {

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -600,11 +600,6 @@ public class NMDbusConnector {
             connection.get().UpdateUnsaved(newConnectionSettings);
             Map<String, Map<String, Variant<?>>> cmpConnectionSettings = getAllSettings(connection.get(), deviceType);
 
-            // TODO: Set these in debug
-            logger.info("New connection settings for device {}: {}", deviceId, cmpConnectionSettings);
-            logger.info("");
-            logger.info("Old connection settings for device {}: {}", deviceId, oldConnectionSettings);
-
             if (NMSettingsComparator.areSettingsEqual(cmpConnectionSettings, oldConnectionSettings) ) {
                 logger.info("No changes in connection settings for device {}", deviceId);
             } else {

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -593,7 +593,7 @@ public class NMDbusConnector {
                 && NMSettingsComparator.areSettingsEqual(newConnectionSettings, oldConnectionSettings)) {
             logger.info("No changes detected in connection settings for device {}. Skipping update and activation.",
                     deviceId);
-            return;
+            return; // TODO: actually skip the steps below without skipping the whole method
         }
 
         DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -656,6 +656,10 @@ public class NMDbusConnector {
         Map<String, Map<String, Variant<?>>> allSettings = new HashMap<>();
         allSettings.putAll(connection.GetSettings());
 
+        // Note: when adding a new devie type among the supported ones (i.e.
+        // CONFIGURATION_SUPPORTED_DEVICE_TYPES) make sure to add the related settings
+        // keys here in order to properly retrieve secrets for comparison in
+        // enableInterface method
         String[] settingKeys;
         if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_WIFI)) {
             settingKeys = new String[] {"802-11-wireless", "802-11-wireless-security", "802-1x"};

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -618,9 +618,9 @@ public class NMDbusConnector {
         // Reapply settings anyway to let NM reconfigure the device if needed (e.g. Modem connection failures)
         boolean isReapplySuccessful = this.networkManager.reapplySettings(device, newConnectionSettings);
 
-        if (!isReapplySuccessful) {
+        if(!isReapplySuccessful) {
             try {
-                logger.info("Reapply failed. Activating connection for device {}", deviceId);
+                logger.info("Activating connection for device {}", deviceId);
                 this.networkManager.activateConnection(connection.get(), device);
                 dsLock.waitForSignal();
             } catch (DBusExecutionException e) {

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -589,6 +589,13 @@ public class NMDbusConnector {
                 connection, deviceId, interfaceName, deviceType, this.networkManager.getVersion());
         
         Map<String, Map<String, Variant<?>>> oldConnectionSettings = connection.isPresent() ? connection.get().GetSettings() : null;
+        
+        // Debug: print settings (remove in production)
+        logger.info("New connection settings for device {}: {}", deviceId, newConnectionSettings);
+        logger.info("Old connection settings for device {}: {}", deviceId, oldConnectionSettings);
+        logger.info("Settings equal: {}", NMSettingsComparator.areSettingsEqual(newConnectionSettings, oldConnectionSettings));
+        // End Debug
+        
         if (Objects.isNull(oldConnectionSettings)
                 || !NMSettingsComparator.areSettingsEqual(newConnectionSettings, oldConnectionSettings)) {
 

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -621,15 +621,15 @@ public class NMDbusConnector {
             connection = Optional.of(createdConnection);
         }
       
-        if (!skipActivation) {       
-            boolean isReapplySuccessful = this.networkManager.reapplySettings(device, newConnectionSettings);
-            if(!isReapplySuccessful) {
-                try {
-                    this.networkManager.activateConnection(connection.get(), device);
-                    dsLock.waitForSignal();
-                } catch (DBusExecutionException e) {
-                    logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
-                }
+        // Reapply settings anyway to let NM reconfigure the device if needed (e.g. Modem connection failures)
+        boolean isReapplySuccessful = this.networkManager.reapplySettings(device, newConnectionSettings);
+
+        if (!skipActivation || !isReapplySuccessful) {
+            try {
+                this.networkManager.activateConnection(connection.get(), device);
+                dsLock.waitForSignal();
+            } catch (DBusExecutionException e) {
+                logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
             }
         }
 

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -589,31 +589,32 @@ public class NMDbusConnector {
                 connection, deviceId, interfaceName, deviceType, this.networkManager.getVersion());
         
         Map<String, Map<String, Variant<?>>> oldConnectionSettings = connection.isPresent() ? connection.get().GetSettings() : null;
-        if (Objects.nonNull(oldConnectionSettings)
-                && NMSettingsComparator.areSettingsEqual(newConnectionSettings, oldConnectionSettings)) {
-            logger.info("No changes detected in connection settings for device {}. Skipping update and activation.",
-                    deviceId);
-            return; // TODO: actually skip the steps below without skipping the whole method
-        }
+        if (Objects.isNull(oldConnectionSettings)
+                || !NMSettingsComparator.areSettingsEqual(newConnectionSettings, oldConnectionSettings)) {
 
-        DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),
+            DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),
                 NMDeviceState.NM_DEVICE_STATE_CONFIG, this.timeout);
 
-        if (connection.isPresent()) {
-            connection.get().Update(newConnectionSettings);
-        } else {
-            Settings settings = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_SETTINGS_BUS_PATH, Settings.class);
-            DBusPath createdConnectionPath = settings.AddConnection(newConnectionSettings);
-            Connection createdConnection = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
-                    createdConnectionPath.getPath(), Connection.class);
-            connection = Optional.of(createdConnection);
-        }
+            if (connection.isPresent()) {
+                connection.get().Update(newConnectionSettings);
+            } else {
+                Settings settings = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_SETTINGS_BUS_PATH, Settings.class);
+                DBusPath createdConnectionPath = settings.AddConnection(newConnectionSettings);
+                Connection createdConnection = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
+                        createdConnectionPath.getPath(), Connection.class);
+                connection = Optional.of(createdConnection);
+            }
 
-        try {
-            this.networkManager.activateConnection(connection.get(), device);
-            dsLock.waitForSignal();
-        } catch (DBusExecutionException e) {
-            logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
+            try {
+                this.networkManager.activateConnection(connection.get(), device);
+                dsLock.waitForSignal();
+            } catch (DBusExecutionException e) {
+                logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
+            }
+
+        } else {
+            logger.info("No changes detected in connection settings for device {}. Skipping update and activation.",
+                    deviceId);
         }
 
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -16,6 +16,7 @@ package org.eclipse.kura.nm;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -595,17 +596,16 @@ public class NMDbusConnector {
         if (connection.isPresent()) {
             // Compare old and new settings. Given that NetworkManager may remove paramters from the settings
             // (e.g., removing 802.1x settings when not used), we need NM to pre-ingest the new settings
-            Map<String, Map<String, Variant<?>>> oldConnectionSettings = connection.get().GetSettings();
-            // Map<String, Map<String, Variant<?>>> oldConnectionSecrets = connection.get().GetSecrets();
+            Map<String, Map<String, Variant<?>>> oldConnectionSettings = getAllSettings(connection.get());
             connection.get().UpdateUnsaved(newConnectionSettings);
-            Map<String, Map<String, Variant<?>>> cmpConnectionSettings = connection.get().GetSettings();
-            // Map<String, Map<String, Variant<?>>> cmpConnectionSecrets = connection.get().GetSecrets();
-            
+            Map<String, Map<String, Variant<?>>> cmpConnectionSettings = getAllSettings(connection.get());
+
             // TODO: Set these in debug
             logger.info("New connection settings for device {}: {}", deviceId, cmpConnectionSettings);
+            logger.info("");
             logger.info("Old connection settings for device {}: {}", deviceId, oldConnectionSettings);
 
-            if (NMSettingsComparator.areSettingsEqual(cmpConnectionSettings, oldConnectionSettings)) {
+            if (NMSettingsComparator.areSettingsEqual(cmpConnectionSettings, oldConnectionSettings) ) {
                 logger.info("No changes in connection settings for device {}", deviceId);
                 skipActivation = true;
             } else {
@@ -642,6 +642,24 @@ public class NMDbusConnector {
             }
         }
 
+    }
+
+    private Map<String, Map<String, Variant<?>>> getAllSettings(Connection connection) {
+        Map<String, Map<String, Variant<?>>> allSettings = new HashMap<>();
+        allSettings.putAll(connection.GetSettings());
+
+        String[] settingKeys = {"802-11-wireless-security", "802-1x", "gsm", "cdma", "ppp"};
+        for (String settingKey : settingKeys) {
+            try {
+                Map<String, Map<String, Variant<?>>> secrets = connection.GetSecrets(settingKey);
+                // Merge the secrets into the allSettings map
+                allSettings.put(settingKey, secrets.get(settingKey));
+            } catch (DBusExecutionException e) {
+                // Ignore exception, it means that there are no secrets for this setting, which is fine
+            }
+        }
+
+        return allSettings;
     }
 
     private void createVirtualInterface(String deviceId, NetworkProperties properties, NMDeviceType deviceType)

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -572,12 +572,7 @@ public class NMDbusConnector {
     private void enableInterface(String deviceId, NetworkProperties properties, Optional<Device> device,
             NMDeviceType deviceType) throws DBusException {
         if (device.isPresent()) {
-            long start;
-            long stop;
-            start = System.currentTimeMillis();
             enableInterface(deviceId, properties, device.get(), deviceType);
-            stop = System.currentTimeMillis();
-            logger.info("Enabling interface {} took {} ms", deviceId, (stop - start));
         } else {
             createVirtualInterface(deviceId, properties, deviceType);
         }

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -656,13 +656,17 @@ public class NMDbusConnector {
         Map<String, Map<String, Variant<?>>> allSettings = new HashMap<>();
         allSettings.putAll(connection.GetSettings());
 
-        // Note: when adding a new device type among the supported ones make sure to add
-        // the related settings keys here in order to properly retrieve secrets for
-        // comparison in enableInterface method
         if(!CONFIGURATION_SUPPORTED_DEVICE_TYPES.contains(deviceType)) {
+            // This check here is just to ensure that if a new device type is added to the
+            // supported list but not added here, we don't end up with an empty secrets map
+            // which would cause wrong comparison results in enableInterface method
             throw new IllegalArgumentException(
                     String.format("Device type %s not supported for secret settings retrieval", deviceType));
         }
+
+        // Note: when adding a new device type among the supported ones make sure to add
+        // the related settings keys here in order to properly retrieve secrets for
+        // comparison in enableInterface method
         String[] settingKeys;
         if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_WIFI)) {
             settingKeys = new String[] {"802-11-wireless", "802-11-wireless-security", "802-1x"};

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -20,6 +20,10 @@ import org.freedesktop.dbus.types.Variant;
 
 public class NMSettingsComparator {
 
+    private NMSettingsComparator() {
+        throw new IllegalStateException("Utility class");
+    }
+
     /* This method compares two NM connection settings maps and determines if they are equal. This comparison
      * is asymmetric, meaning that if newConnectionSettings contains all the settings in oldConnectionSettings with the same
      * values, it is considered equal, even if oldConnectionSettings has additional settings.

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -1,0 +1,15 @@
+package org.eclipse.kura.nm.configuration;
+
+import java.util.Map;
+
+import org.freedesktop.dbus.types.Variant;
+
+public class NMSettingsComparator {
+
+    public static boolean areSettingsEqual(Map<String,Map<String,Variant<?>>> newConnectionSettings,
+            Map<String,Map<String,Variant<?>>> oldConnectionSettings) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+}

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -1,12 +1,13 @@
 package org.eclipse.kura.nm.configuration;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 
 import org.freedesktop.dbus.types.Variant;
 
 public class NMSettingsComparator {
-    
+
     /* This method compares two NM connection settings maps and determines if they are equal. This comparison
      * is asymmetric, meaning that if newConnectionSettings contains all the settings in oldConnectionSettings with the same
      * values, it is considered equal, even if oldConnectionSettings has additional settings.
@@ -17,15 +18,15 @@ public class NMSettingsComparator {
      */
     public static boolean areSettingsEqual(Map<String,Map<String,Variant<?>>> newConnectionSettings,
             Map<String,Map<String,Variant<?>>> oldConnectionSettings) {
-        
+
         if(Objects.isNull(newConnectionSettings)) {
             throw new IllegalArgumentException("New connection settings cannot be null");
         }
-        
+
         if(Objects.isNull(oldConnectionSettings)) {
             return false;
         }
-        
+
         for (String settingKey : newConnectionSettings.keySet()) {
             Map<String, Variant<?>> newSetting = newConnectionSettings.get(settingKey);
             Map<String, Variant<?>> oldSetting = oldConnectionSettings.get(settingKey);
@@ -38,13 +39,33 @@ public class NMSettingsComparator {
                 Variant<?> newValue = newSetting.get(propertyKey);
                 Variant<?> oldValue = oldSetting.get(propertyKey);
 
-                if (!Objects.equals(newValue, oldValue)) {
+                if (!areVariantsEqual(newValue, oldValue)) {
                     return false;
                 }
             }
         }
 
         return true;
+    }
+
+    private static boolean areVariantsEqual(Variant<?> newValue, Variant<?> oldValue) {
+        if (newValue == null && oldValue == null) {
+            return true;
+        }
+
+        if (newValue == null || oldValue == null) {
+            return false;
+        }
+
+        Object newObject = newValue.getValue();
+        Object oldObject = oldValue.getValue();
+
+        // Special handling for byte arrays
+        if (newObject instanceof byte[] && oldObject instanceof byte[]) {
+            return Arrays.equals((byte[]) newObject, (byte[]) oldObject);
+        }
+
+        return Objects.equals(newValue, oldValue);
     }
 
 }

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -29,6 +29,8 @@ public class NMSettingsComparator {
      * @param newConnectionSettings The new connection settings to compare.
      * @param oldConnectionSettings The old connection settings to compare against.
      * @return true if the settings are considered equal, false otherwise.
+     *
+     * @throws IllegalArgumentException if either of the connection settings maps is null.
      */
     public static boolean areSettingsEqual(Map<String,Map<String,Variant<?>>> newConnectionSettings,
             Map<String,Map<String,Variant<?>>> oldConnectionSettings) {
@@ -54,6 +56,12 @@ public class NMSettingsComparator {
     }
 
     private static boolean areNestedMapsEqual(Map<String, Variant<?>> newNested, Map<String, Variant<?>> oldNested) {
+        if(Objects.isNull(newNested) || Objects.isNull(oldNested)) {
+            // NM settings should never have null nested maps, they would simply be omitted
+            // from the top-level map.
+            throw new IllegalArgumentException("Nested maps cannot be null");
+        }
+
         if (!newNested.keySet().equals(oldNested.keySet())) {
             return false;
         }

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -6,6 +6,14 @@ import org.freedesktop.dbus.types.Variant;
 
 public class NMSettingsComparator {
 
+    /* This method compares two NM connection settings maps and determines if they are equal. This comparison
+     * is asymmetric, meaning that if newConnectionSettings contains all the settings in oldConnectionSettings with the same
+     * values, it is considered equal, even if oldConnectionSettings has additional settings.
+     *
+     * @param newConnectionSettings The new connection settings to compare.
+     * @param oldConnectionSettings The old connection settings to compare against. Can be a superset of newConnectionSettings.
+     * @return true if the settings are considered equal, false otherwise.
+     */
     public static boolean areSettingsEqual(Map<String,Map<String,Variant<?>>> newConnectionSettings,
             Map<String,Map<String,Variant<?>>> oldConnectionSettings) {
         // TODO Auto-generated method stub

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -1,10 +1,15 @@
 package org.eclipse.kura.nm.configuration;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.freedesktop.dbus.types.Variant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NMSettingsComparator {
+    
+    private static final Logger logger = LoggerFactory.getLogger(NMSettingsComparator.class);
 
     /* This method compares two NM connection settings maps and determines if they are equal. This comparison
      * is asymmetric, meaning that if newConnectionSettings contains all the settings in oldConnectionSettings with the same
@@ -16,8 +21,38 @@ public class NMSettingsComparator {
      */
     public static boolean areSettingsEqual(Map<String,Map<String,Variant<?>>> newConnectionSettings,
             Map<String,Map<String,Variant<?>>> oldConnectionSettings) {
-        // TODO Auto-generated method stub
-        return false;
+        
+        logger.info("Comparing new connection settings: {}", newConnectionSettings);
+        logger.info("With old connection settings: {}", oldConnectionSettings);
+        
+        if(Objects.isNull(newConnectionSettings)) {
+            throw new IllegalArgumentException("New connection settings cannot be null");
+        }
+        
+        if(Objects.isNull(oldConnectionSettings)) {
+            return false;
+        }
+        
+        // WARNING: This implementation doesn't work when properties are other Map<String, Variant<?>>, as it doesn't perform a deep comparison.
+        for (String settingKey : newConnectionSettings.keySet()) {
+            Map<String, Variant<?>> newSetting = newConnectionSettings.get(settingKey);
+            Map<String, Variant<?>> oldSetting = oldConnectionSettings.get(settingKey);
+
+            if (oldSetting == null) {
+                return false;
+            }
+
+            for (String propertyKey : newSetting.keySet()) {
+                Variant<?> newValue = newSetting.get(propertyKey);
+                Variant<?> oldValue = oldSetting.get(propertyKey);
+
+                if (!Objects.equals(newValue, oldValue)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
 }

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -79,22 +79,14 @@ public class NMSettingsComparator {
     }
 
     private static boolean areVariantsEqual(Variant<?> newVariant, Variant<?> oldVariant) {
-        if (newVariant == null && oldVariant == null) {
-            return true;
-        }
-        if (newVariant == null || oldVariant == null) {
-            return false;
+        if (Objects.isNull(newVariant) || Objects.isNull(oldVariant)) {
+            // NM settings should never have null variants, they would simply be omitted
+            // from the nested map.
+            throw new IllegalArgumentException("Variants cannot be null");
         }
 
         Object newValue = newVariant.getValue();
         Object oldValue = oldVariant.getValue();
-
-        if (newValue == null && oldValue == null) {
-            return true;
-        }
-        if (newValue == null || oldValue == null) {
-            return false;
-        }
 
         if (newValue instanceof byte[] newByteArray && oldValue instanceof byte[] oldByteArray) {
             return Arrays.equals(newByteArray, oldByteArray);

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -33,7 +33,6 @@ public class NMSettingsComparator {
             return false;
         }
         
-        // WARNING: This implementation doesn't work when properties are other Map<String, Variant<?>>, as it doesn't perform a deep comparison.
         for (String settingKey : newConnectionSettings.keySet()) {
             Map<String, Variant<?>> newSetting = newConnectionSettings.get(settingKey);
             Map<String, Variant<?>> oldSetting = oldConnectionSettings.get(settingKey);

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -4,13 +4,9 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.freedesktop.dbus.types.Variant;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class NMSettingsComparator {
     
-    private static final Logger logger = LoggerFactory.getLogger(NMSettingsComparator.class);
-
     /* This method compares two NM connection settings maps and determines if they are equal. This comparison
      * is asymmetric, meaning that if newConnectionSettings contains all the settings in oldConnectionSettings with the same
      * values, it is considered equal, even if oldConnectionSettings has additional settings.
@@ -21,9 +17,6 @@ public class NMSettingsComparator {
      */
     public static boolean areSettingsEqual(Map<String,Map<String,Variant<?>>> newConnectionSettings,
             Map<String,Map<String,Variant<?>>> oldConnectionSettings) {
-        
-        logger.info("Comparing new connection settings: {}", newConnectionSettings);
-        logger.info("With old connection settings: {}", oldConnectionSettings);
         
         if(Objects.isNull(newConnectionSettings)) {
             throw new IllegalArgumentException("New connection settings cannot be null");

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.eclipse.kura.nm.configuration;
 
 import java.util.Arrays;

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsComparator.java
@@ -24,64 +24,74 @@ public class NMSettingsComparator {
         throw new IllegalStateException("Utility class");
     }
 
-    /* This method compares two NM connection settings maps and determines if they are equal. This comparison
-     * is asymmetric, meaning that if newConnectionSettings contains all the settings in oldConnectionSettings with the same
-     * values, it is considered equal, even if oldConnectionSettings has additional settings.
+    /* This method compares two NM connection settings maps and determines if they are equal.
      *
      * @param newConnectionSettings The new connection settings to compare.
-     * @param oldConnectionSettings The old connection settings to compare against. Can be a superset of newConnectionSettings.
+     * @param oldConnectionSettings The old connection settings to compare against.
      * @return true if the settings are considered equal, false otherwise.
      */
     public static boolean areSettingsEqual(Map<String,Map<String,Variant<?>>> newConnectionSettings,
             Map<String,Map<String,Variant<?>>> oldConnectionSettings) {
 
-        if(Objects.isNull(newConnectionSettings)) {
-            throw new IllegalArgumentException("New connection settings cannot be null");
+        if(Objects.isNull(newConnectionSettings) || Objects.isNull(oldConnectionSettings)) {
+            throw new IllegalArgumentException("Connection settings cannot be null");
         }
 
-        if(Objects.isNull(oldConnectionSettings)) {
+        if (!newConnectionSettings.keySet().equals(oldConnectionSettings.keySet())) {
             return false;
         }
 
-        for (String settingKey : newConnectionSettings.keySet()) {
-            Map<String, Variant<?>> newSetting = newConnectionSettings.get(settingKey);
-            Map<String, Variant<?>> oldSetting = oldConnectionSettings.get(settingKey);
+        for (String topLevelKey : newConnectionSettings.keySet()) {
+            Map<String, Variant<?>> newNested = newConnectionSettings.get(topLevelKey);
+            Map<String, Variant<?>> oldNested = oldConnectionSettings.get(topLevelKey);
 
-            if (oldSetting == null) {
+            if (!areNestedMapsEqual(newNested, oldNested)) {
                 return false;
-            }
-
-            for (String propertyKey : newSetting.keySet()) {
-                Variant<?> newValue = newSetting.get(propertyKey);
-                Variant<?> oldValue = oldSetting.get(propertyKey);
-
-                if (!areVariantsEqual(newValue, oldValue)) {
-                    return false;
-                }
             }
         }
 
         return true;
     }
 
-    private static boolean areVariantsEqual(Variant<?> newValue, Variant<?> oldValue) {
+    private static boolean areNestedMapsEqual(Map<String, Variant<?>> newNested, Map<String, Variant<?>> oldNested) {
+        if (!newNested.keySet().equals(oldNested.keySet())) {
+            return false;
+        }
+
+        for (String nestedKey : newNested.keySet()) {
+            Variant<?> newVariant = newNested.get(nestedKey);
+            Variant<?> oldVariant = oldNested.get(nestedKey);
+
+            if (!areVariantsEqual(newVariant, oldVariant)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean areVariantsEqual(Variant<?> newVariant, Variant<?> oldVariant) {
+        if (newVariant == null && oldVariant == null) {
+            return true;
+        }
+        if (newVariant == null || oldVariant == null) {
+            return false;
+        }
+
+        Object newValue = newVariant.getValue();
+        Object oldValue = oldVariant.getValue();
+
         if (newValue == null && oldValue == null) {
             return true;
         }
-
         if (newValue == null || oldValue == null) {
             return false;
         }
 
-        Object newObject = newValue.getValue();
-        Object oldObject = oldValue.getValue();
-
-        // Special handling for byte arrays
-        if (newObject instanceof byte[] && oldObject instanceof byte[]) {
-            return Arrays.equals((byte[]) newObject, (byte[]) oldObject);
+        if (newValue instanceof byte[] newByteArray && oldValue instanceof byte[] oldByteArray) {
+            return Arrays.equals(newByteArray, oldByteArray);
         }
 
         return Objects.equals(newValue, oldValue);
     }
-
 }

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1948,7 +1948,7 @@ public class NMDbusConnectorTest {
     private void thenConnectionUpdateIsCalledFor(String netInterface) throws DBusException {
         Connection connect = this.dbusConnection.getRemoteObject("org.freedesktop.NetworkManager",
                 "/mock/device/" + netInterface, Connection.class);
-        verify(connect).Update(any());
+        verify(connect).UpdateUnsaved(any());
     }
 
     private void thenConnectionUpdateIsNotCalledFor(String netInterface) throws DBusException {

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1465,6 +1465,7 @@ public class NMDbusConnectorTest {
         if (hasAssociatedConnection) {
             this.mockConnection = mock(Connection.class, RETURNS_SMART_NULLS);
             when(this.mockConnection.GetSettings()).thenReturn(mockedDevice1ConnectionSetting);
+            when(this.mockConnection.GetSecrets(any())).thenThrow(new DBusExecutionException("No secrets available"));
 
             doReturn(this.mockConnection).when(this.dbusConnection).getRemoteObject("org.freedesktop.NetworkManager",
                     "/mock/device/" + interfaceId, Connection.class);

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -12,66 +12,113 @@
  *******************************************************************************/
 package org.eclipse.kura.nm.configuration;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateEncodingException;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Optional;
-
-import javax.crypto.EncryptedPrivateKeyInfo;
-import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
-
-import org.eclipse.kura.configuration.Password;
-import org.eclipse.kura.nm.NetworkProperties;
-import org.eclipse.kura.nm.SemanticVersion;
-import org.eclipse.kura.nm.enums.NMDeviceType;
-import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.Variant;
-import org.freedesktop.networkmanager.settings.Connection;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 public class NMSettingsComparatorTest {
 
     private Map<String, Map<String, Variant<?>>> newSettings = new HashMap<>();
     private Map<String, Map<String, Variant<?>>> oldSettings = new HashMap<>();
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenNewSettingsAreNull() {
+        NMSettingsComparator.areSettingsEqual(null, oldSettings);
+    }
 
     @Test
-    public void basicTest() {
+    public void returnsTrueWhenSettingsAreEqual() {
         newSettings.put("connection", new HashMap<>());
         newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
         
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
 
         assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+
+    @Test
+    public void returnsTrueWhenSettingsAreEqualButSubset() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+        
+        oldSettings.put("ipv4", new HashMap<>());
+        oldSettings.get("ipv4").put("method", new Variant<String>("auto"));
+
+        assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+    
+    @Test
+    public void returnsTrueWhenBothSettingsAreEmpty() {
+        assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+    
+    @Test
+    public void returnsTrueWhenNewSettingsAreEmpty() {
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+
+    @Test
+    public void returnsFalseWhenOldSettingsAreNull() {
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, null));
+    }
+
+    @Test
+    public void returnsFalseWhenSettingsAreNotEqual() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+        
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My Ethernet"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(2));
+
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+
+    @Test
+    public void returnsFalseWhenSettingsAreNotEqualButSubset() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+        
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My Ethernet"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(2));
+
+        oldSettings.put("ipv4", new HashMap<>());
+        oldSettings.get("ipv4").put("method", new Variant<String>("auto"));
+
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+
+    @Test
+    public void returnsFalseWhenSettingsAreEqualButSuperset() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        newSettings.put("ipv4", new HashMap<>());
+        newSettings.get("ipv4").put("method", new Variant<String>("auto"));
+        
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My Ethernet"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(2));
+
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
 }

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -14,8 +14,13 @@ package org.eclipse.kura.nm.configuration;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.Variant;
 import org.junit.Test;
 
@@ -57,6 +62,39 @@ public class NMSettingsComparatorTest {
 
         assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
+
+    @Test
+    public void returnsTrueWhenSettingsAreEqualAndMapVariant() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        newSettings.put("ipv4", new HashMap<>());
+        newSettings.get("ipv4").put("method", new Variant<String>("manual"));
+
+        Map<String, Variant<?>> newAddressEntry = new HashMap<>();
+        newAddressEntry.put("address", new Variant<>("172.16.1.1"));
+        newAddressEntry.put("prefix", new Variant<>(new UInt32(24)));
+        List<Map<String, Variant<?>>> newAddressData = Arrays.asList(newAddressEntry);
+        newSettings.get("ipv4").put("address-data", new Variant<>(newAddressData, "aa{sv}"));
+
+        
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My Ethernet"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(2));
+
+        oldSettings.put("ipv4", new HashMap<>());
+        oldSettings.get("ipv4").put("method", new Variant<String>("manual"));
+
+        Map<String, Variant<?>> oldAddressEntry = new HashMap<>();
+        oldAddressEntry.put("address", new Variant<>("172.16.1.1"));
+        oldAddressEntry.put("prefix", new Variant<>(new UInt32(24)));
+        List<Map<String, Variant<?>>> oldAddressData = Arrays.asList(oldAddressEntry);
+        oldSettings.get("ipv4").put("address-data", new Variant<>(oldAddressData, "aa{sv}"));
+
+        assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+
     
     @Test
     public void returnsTrueWhenBothSettingsAreEmpty() {
@@ -89,6 +127,39 @@ public class NMSettingsComparatorTest {
 
         assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
+
+    @Test
+    public void returnsFalseWhenSettingsAreNotEqualAndMapVariant() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        newSettings.put("ipv4", new HashMap<>());
+        newSettings.get("ipv4").put("method", new Variant<String>("manual"));
+
+        Map<String, Variant<?>> newAddressEntry = new HashMap<>();
+        newAddressEntry.put("address", new Variant<>("172.16.1.1"));
+        newAddressEntry.put("prefix", new Variant<>(new UInt32(24)));
+        List<Map<String, Variant<?>>> newAddressData = Arrays.asList(newAddressEntry);
+        newSettings.get("ipv4").put("address-data", new Variant<>(newAddressData, "aa{sv}"));
+
+        
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My Ethernet"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(2));
+
+        oldSettings.put("ipv4", new HashMap<>());
+        oldSettings.get("ipv4").put("method", new Variant<String>("manual"));
+
+        Map<String, Variant<?>> oldAddressEntry = new HashMap<>();
+        oldAddressEntry.put("address", new Variant<>("172.16.1.2"));
+        oldAddressEntry.put("prefix", new Variant<>(new UInt32(24)));
+        List<Map<String, Variant<?>>> oldAddressData = Arrays.asList(oldAddressEntry);
+        oldSettings.get("ipv4").put("address-data", new Variant<>(oldAddressData, "aa{sv}"));
+
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+
 
     @Test
     public void returnsFalseWhenSettingsAreNotEqualButSubset() {

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -145,8 +145,8 @@ public class NMSettingsComparatorTest {
 
         
         oldSettings.put("connection", new HashMap<>());
-        oldSettings.get("connection").put("id", new Variant<String>("My Ethernet"));
-        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(2));
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
 
         oldSettings.put("ipv4", new HashMap<>());
         oldSettings.get("ipv4").put("method", new Variant<String>("manual"));

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -66,11 +66,47 @@ public class NMSettingsComparatorTest {
         NMSettingsComparator.areSettingsEqual(newSettings, oldSettings);
     }
 
-
     @Test(expected = IllegalArgumentException.class)
     public void throwsWhenBothNestedMapAreNull() {
         newSettings.put("connection", null);
         oldSettings.put("connection", null);
+        NMSettingsComparator.areSettingsEqual(newSettings, oldSettings);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenNewVariantIsNull() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", null);
+
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+        NMSettingsComparator.areSettingsEqual(newSettings, oldSettings);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenOldVariantIsNull() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", null);
+
+        NMSettingsComparator.areSettingsEqual(newSettings, oldSettings);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenBothVariantsAreNull() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", null);
+
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", null);
         NMSettingsComparator.areSettingsEqual(newSettings, oldSettings);
     }
 

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -45,6 +45,35 @@ public class NMSettingsComparatorTest {
         NMSettingsComparator.areSettingsEqual(null, null);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenNewNestedMapIsNull() {
+        newSettings.put("connection", null);
+
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        NMSettingsComparator.areSettingsEqual(newSettings, oldSettings);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenOldNestedMapIsNull() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        oldSettings.put("connection", null);
+        NMSettingsComparator.areSettingsEqual(newSettings, oldSettings);
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenBothNestedMapAreNull() {
+        newSettings.put("connection", null);
+        oldSettings.put("connection", null);
+        NMSettingsComparator.areSettingsEqual(newSettings, oldSettings);
+    }
+
     @Test
     public void returnsTrueWhenSettingsAreEqual() {
         newSettings.put("connection", new HashMap<>());

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -244,4 +244,54 @@ public class NMSettingsComparatorTest {
 
         assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
+
+    @Test
+    public void returnsTrueWhenSettingsAreEqualWithStringList() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+
+        newSettings.put("ipv4", new HashMap<>());
+        newSettings.get("ipv4").put("method", new Variant<String>("manual"));
+
+        List<String> newDnsServers = Arrays.asList("8.8.8.8", "8.8.4.4");
+        newSettings.get("ipv4").put("dns", new Variant<>(newDnsServers, "as"));
+        newSettings.get("ipv4").put("ignore-auto-dns", new Variant<>(true));
+
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+
+        oldSettings.put("ipv4", new HashMap<>());
+        oldSettings.get("ipv4").put("method", new Variant<String>("manual"));
+
+        List<String> oldDnsServers = Arrays.asList("8.8.8.8", "8.8.4.4");
+        oldSettings.get("ipv4").put("dns", new Variant<>(oldDnsServers, "as"));
+        oldSettings.get("ipv4").put("ignore-auto-dns", new Variant<>(true));
+
+        assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+
+    @Test
+    public void returnsFalseWhenSettingsAreNotEqualWithStringList() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+
+        newSettings.put("ipv4", new HashMap<>());
+        newSettings.get("ipv4").put("method", new Variant<String>("manual"));
+
+        List<String> newDnsServers = Arrays.asList("8.8.8.8", "8.8.4.4");
+        newSettings.get("ipv4").put("dns", new Variant<>(newDnsServers, "as"));
+        newSettings.get("ipv4").put("ignore-auto-dns", new Variant<>(true));
+
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+
+        oldSettings.put("ipv4", new HashMap<>());
+        oldSettings.get("ipv4").put("method", new Variant<String>("manual"));
+
+        List<String> oldDnsServers = Arrays.asList("1.1.1.1", "1.0.0.1");
+        oldSettings.get("ipv4").put("dns", new Variant<>(oldDnsServers, "as"));
+        oldSettings.get("ipv4").put("ignore-auto-dns", new Variant<>(true));
+
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
 }

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.nm.configuration;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.crypto.EncryptedPrivateKeyInfo;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import org.eclipse.kura.configuration.Password;
+import org.eclipse.kura.nm.NetworkProperties;
+import org.eclipse.kura.nm.SemanticVersion;
+import org.eclipse.kura.nm.enums.NMDeviceType;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+import org.freedesktop.networkmanager.settings.Connection;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class NMSettingsComparatorTest {
+
+    private Map<String, Map<String, Variant<?>>> newSettings = new HashMap<>();
+    private Map<String, Map<String, Variant<?>>> oldSettings = new HashMap<>();
+
+    @Test
+    public void basicTest() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+
+        assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+}

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -116,6 +116,15 @@ public class NMSettingsComparatorTest {
     }
 
     @Test
+    public void returnsFalseWhenOldSettingsAreEmpty() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+
+    @Test
     public void returnsFalseWhenSettingsAreNotEqual() {
         newSettings.put("connection", new HashMap<>());
         newSettings.get("connection").put("id", new Variant<String>("My WiFi"));

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -35,6 +35,16 @@ public class NMSettingsComparatorTest {
         NMSettingsComparator.areSettingsEqual(null, oldSettings);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenOldSettingsAreNull() {
+        NMSettingsComparator.areSettingsEqual(newSettings, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsWhenBothSettingsAreNull() {
+        NMSettingsComparator.areSettingsEqual(null, null);
+    }
+
     @Test
     public void returnsTrueWhenSettingsAreEqual() {
         newSettings.put("connection", new HashMap<>());
@@ -70,7 +80,7 @@ public class NMSettingsComparatorTest {
     }
 
     @Test
-    public void returnsTrueWhenSettingsAreEqualButSubset() {
+    public void returnsFalseWhenSettingsAreEqualButSubset() {
         newSettings.put("connection", new HashMap<>());
         newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
@@ -82,7 +92,7 @@ public class NMSettingsComparatorTest {
         oldSettings.put("ipv4", new HashMap<>());
         oldSettings.get("ipv4").put("method", new Variant<String>("auto"));
 
-        assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
 
     @Test
@@ -100,7 +110,6 @@ public class NMSettingsComparatorTest {
         List<Map<String, Variant<?>>> newAddressData = Arrays.asList(newAddressEntry);
         newSettings.get("ipv4").put("address-data", new Variant<>(newAddressData, "aa{sv}"));
 
-
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
@@ -117,24 +126,18 @@ public class NMSettingsComparatorTest {
         assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
 
-
     @Test
     public void returnsTrueWhenBothSettingsAreEmpty() {
         assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
 
     @Test
-    public void returnsTrueWhenNewSettingsAreEmpty() {
+    public void returnsFalseWhenNewSettingsAreEmpty() {
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
 
-        assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
-    }
-
-    @Test
-    public void returnsFalseWhenOldSettingsAreNull() {
-        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, null));
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
 
     @Test
@@ -194,7 +197,6 @@ public class NMSettingsComparatorTest {
         List<Map<String, Variant<?>>> newAddressData = Arrays.asList(newAddressEntry);
         newSettings.get("ipv4").put("address-data", new Variant<>(newAddressData, "aa{sv}"));
 
-
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
@@ -210,7 +212,6 @@ public class NMSettingsComparatorTest {
 
         assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
-
 
     @Test
     public void returnsFalseWhenSettingsAreNotEqualButSubset() {

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -80,8 +80,8 @@ public class NMSettingsComparatorTest {
 
         
         oldSettings.put("connection", new HashMap<>());
-        oldSettings.get("connection").put("id", new Variant<String>("My Ethernet"));
-        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(2));
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
 
         oldSettings.put("ipv4", new HashMap<>());
         oldSettings.get("ipv4").put("method", new Variant<String>("manual"));

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -15,6 +15,7 @@ package org.eclipse.kura.nm.configuration;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -28,7 +29,7 @@ public class NMSettingsComparatorTest {
 
     private Map<String, Map<String, Variant<?>>> newSettings = new HashMap<>();
     private Map<String, Map<String, Variant<?>>> oldSettings = new HashMap<>();
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void throwsWhenNewSettingsAreNull() {
         NMSettingsComparator.areSettingsEqual(null, oldSettings);
@@ -39,10 +40,31 @@ public class NMSettingsComparatorTest {
         newSettings.put("connection", new HashMap<>());
         newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
-        
+
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+
+    @Test
+    public void returnsTrueWhenSettingsAreEqualWithByteArray() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        newSettings.put("802-11-wireless", new HashMap<>());
+        String newSSID = "MyWiFiSSID";
+        newSettings.get("802-11-wireless").put("ssid", new Variant<>(newSSID.getBytes(StandardCharsets.UTF_8)));
+
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        oldSettings.put("802-11-wireless", new HashMap<>());
+        String oldSSID = "MyWiFiSSID";
+        oldSettings.get("802-11-wireless").put("ssid", new Variant<>(oldSSID.getBytes(StandardCharsets.UTF_8)));
 
         assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
@@ -56,7 +78,7 @@ public class NMSettingsComparatorTest {
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
-        
+
         oldSettings.put("ipv4", new HashMap<>());
         oldSettings.get("ipv4").put("method", new Variant<String>("auto"));
 
@@ -78,7 +100,7 @@ public class NMSettingsComparatorTest {
         List<Map<String, Variant<?>>> newAddressData = Arrays.asList(newAddressEntry);
         newSettings.get("ipv4").put("address-data", new Variant<>(newAddressData, "aa{sv}"));
 
-        
+
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
@@ -95,12 +117,12 @@ public class NMSettingsComparatorTest {
         assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
 
-    
+
     @Test
     public void returnsTrueWhenBothSettingsAreEmpty() {
         assertTrue(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
-    
+
     @Test
     public void returnsTrueWhenNewSettingsAreEmpty() {
         oldSettings.put("connection", new HashMap<>());
@@ -129,7 +151,7 @@ public class NMSettingsComparatorTest {
         newSettings.put("connection", new HashMap<>());
         newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
-        
+
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My Ethernet"));
         oldSettings.get("connection").put("autoconnect-retries", new Variant<>(2));
@@ -137,6 +159,26 @@ public class NMSettingsComparatorTest {
         assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
     }
 
+    @Test
+    public void returnsFalseWhenSettingsAreNotEqualWithByteArray() {
+        newSettings.put("connection", new HashMap<>());
+        newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        newSettings.put("802-11-wireless", new HashMap<>());
+        String newSSID = "MyWiFiSSID";
+        newSettings.get("802-11-wireless").put("ssid", new Variant<>(newSSID.getBytes(StandardCharsets.UTF_8)));
+
+        oldSettings.put("connection", new HashMap<>());
+        oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
+        oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
+
+        oldSettings.put("802-11-wireless", new HashMap<>());
+        String oldSSID = "MyOtherWiFiSSID";
+        oldSettings.get("802-11-wireless").put("ssid", new Variant<>(oldSSID.getBytes(StandardCharsets.UTF_8)));
+
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
     @Test
     public void returnsFalseWhenSettingsAreNotEqualAndMapVariant() {
         newSettings.put("connection", new HashMap<>());
@@ -152,7 +194,7 @@ public class NMSettingsComparatorTest {
         List<Map<String, Variant<?>>> newAddressData = Arrays.asList(newAddressEntry);
         newSettings.get("ipv4").put("address-data", new Variant<>(newAddressData, "aa{sv}"));
 
-        
+
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         oldSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
@@ -175,7 +217,7 @@ public class NMSettingsComparatorTest {
         newSettings.put("connection", new HashMap<>());
         newSettings.get("connection").put("id", new Variant<String>("My WiFi"));
         newSettings.get("connection").put("autoconnect-retries", new Variant<>(1));
-        
+
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My Ethernet"));
         oldSettings.get("connection").put("autoconnect-retries", new Variant<>(2));
@@ -194,7 +236,7 @@ public class NMSettingsComparatorTest {
 
         newSettings.put("ipv4", new HashMap<>());
         newSettings.get("ipv4").put("method", new Variant<String>("auto"));
-        
+
         oldSettings.put("connection", new HashMap<>());
         oldSettings.get("connection").put("id", new Variant<String>("My Ethernet"));
         oldSettings.get("connection").put("autoconnect-retries", new Variant<>(2));

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsComparatorTest.java
@@ -275,6 +275,23 @@ public class NMSettingsComparatorTest {
     }
 
     @Test
+    public void returnsFalseWhenSettingsIntersectionIsEmpty() {
+        newSettings.put("ipv4", new HashMap<>());
+        newSettings.get("ipv4").put("method", new Variant<String>("auto"));
+
+        oldSettings.put("ipv4", new HashMap<>());
+        oldSettings.get("ipv4").put("method", new Variant<String>("manual"));
+
+        Map<String, Variant<?>> oldAddressEntry = new HashMap<>();
+        oldAddressEntry.put("address", new Variant<>("172.16.1.2"));
+        oldAddressEntry.put("prefix", new Variant<>(new UInt32(24)));
+        List<Map<String, Variant<?>>> oldAddressData = Arrays.asList(oldAddressEntry);
+        oldSettings.get("ipv4").put("address-data", new Variant<>(oldAddressData, "aa{sv}"));
+
+        assertFalse(NMSettingsComparator.areSettingsEqual(newSettings, oldSettings));
+    }
+
+    @Test
     public void returnsTrueWhenSettingsAreEqualWithStringList() {
         newSettings.put("connection", new HashMap<>());
         newSettings.get("connection").put("id", new Variant<String>("My WiFi"));


### PR DESCRIPTION
This PR introduces additional checks during the network configuration that prevent unnecessary network configuration save on disk.

When Kura receives a new network configuration it will:
- Build the data structure containing the new settings
- Compare the updated connection settings with the current ones (via the newly introduced `NMSettingsComparator`)
- Update the configuration on disk (via `Connection.Save`) **only if** the settings have changed

References:
- [`GetSettings` DBus API](https://networkmanager.dev/docs/api/latest/gdbus-org.freedesktop.NetworkManager.Settings.Connection.html#gdbus-method-org-freedesktop-NetworkManager-Settings-Connection.GetSettings)
- [`GetSecrets` DBus API](https://networkmanager.dev/docs/api/latest/gdbus-org.freedesktop.NetworkManager.Settings.Connection.html#gdbus-method-org-freedesktop-NetworkManager-Settings-Connection.GetSecrets)
- [Python example for `GetSecrets`](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/main/examples/python/dbus/update-secrets.py?ref_type=heads)
- [Python example handling secrets](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blame/main/examples/python/dbus/list-connections.py#L16)

---

### Note about settings retrieval

As noted in https://github.com/eclipse-kura/kura-networking/pull/36#issuecomment-3841313685, default values are not always provided by the `GetSettings` method. For example `accept-all-mac-addresses` and `mtu` are not populated in the data structure retrieved by `GetSettings` if they are set at their default value.

To ensure a "correct comparison" between new and current settings we decided to let NetworkManager "pre-digest" the new settings leveraging `UpdateUnsaved` method and perform the comparison on the "pre-digested" settings. See:

https://github.com/eclipse-kura/kura-networking/blob/d84b34de9d9174534018b76ea3d6b465124fed20/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java#L599-L608

### Note about coverage

There's no explicit unit test for configuration writes. This is due to how we had to implement the settings retrieval here:

https://github.com/eclipse-kura/kura-networking/blob/ca47325ada8264b814f335a407f1925f1e8d0eca/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java#L604-L606

The mock device we use in our unit tests **always returns** the same mock connection:

https://github.com/eclipse-kura/kura-networking/blob/ca47325ada8264b814f335a407f1925f1e8d0eca/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java#L1405-L1407

https://github.com/eclipse-kura/kura-networking/blob/ca47325ada8264b814f335a407f1925f1e8d0eca/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java#L1465-L1471

To actually "test" that the configuration write happens when there's a configuration change we would need to mock the `UpdateUnsaved` behaviour inside the mock connection logic. Are we actually testing the production code at that point?

Given that coverage is still good I would leave this as-is.

### Note about performance

How much of a performance penalty does this PR introduces? There's quite a few DBus calls to extract the settings to compare.

<details><summary>Details</summary>

Here's the code responsible for measuring the time it takes to configure a single interface.

```java
   private void enableInterface(String deviceId, NetworkProperties properties, Optional<Device> device,
            NMDeviceType deviceType) throws DBusException {
        if (device.isPresent()) {
            long start;
            long stop;
            start = System.currentTimeMillis();
            enableInterface(deviceId, properties, device.get(), deviceType);
            stop = System.currentTimeMillis();
            logger.info("Enabling interface {} took {} ms", deviceId, (stop - start));
        } else {
            createVirtualInterface(deviceId, properties, deviceType);
        }
    }
```

Test performed on a Dy1014: simple Kura restart (i.e. all settings are the same and are re-applied).

Develop:

```
Feb 09 10:38:05 dynagate-10-14 ESF[23999]: Device "lo" of type "NM_DEVICE_TYPE_LOOPBACK" with status "UNMANAGED"/"UNMANAGED" currently not supported
Feb 09 10:38:05 dynagate-10-14 ESF[23999]: Settings iface "eth0":NM_DEVICE_TYPE_ETHERNET
Feb 09 10:38:06 dynagate-10-14 ESF[23999]: Enabling interface eth0 took 595 ms
Feb 09 10:38:06 dynagate-10-14 ESF[23999]: Settings iface "eth1":NM_DEVICE_TYPE_ETHERNET
Feb 09 10:38:06 dynagate-10-14 ESF[23999]: Enabling interface eth1 took 361 ms
Feb 09 10:38:06 dynagate-10-14 ESF[23999]: Settings iface "wlan0":NM_DEVICE_TYPE_WIFI
Feb 09 10:38:07 dynagate-10-14 ESF[23999]: Enabling interface wlan0 took 451 ms
Feb 09 10:38:07 dynagate-10-14 ESF[23999]: Device "p2p0" of type "NM_DEVICE_TYPE_WIFI" not configured. Disabling...
Feb 09 10:38:07 dynagate-10-14 ESF[23999]: Settings iface "3-1.3":NM_DEVICE_TYPE_MODEM
Feb 09 10:38:08 dynagate-10-14 ESF[23999]: Modem 3-1.3 activated. Starting monitoring task...
Feb 09 10:38:08 dynagate-10-14 ESF[23999]: Connection for modem 3-1.3 successful
Feb 09 10:38:08 dynagate-10-14 ESF[23999]: Update NetworkConfigurationService... Done.
Feb 09 10:38:08 dynagate-10-14 ESF[23999]: Activate NetworkConfigurationService... Done.
Feb 09 10:38:08 dynagate-10-14 ESF[23999]: Registering SelfConfiguringComponent - org.eclipse.kura.net.admin.NetworkConfigurationService....
Feb 09 10:38:08 dynagate-10-14 ESF[23999]: Registering SelfConfiguringComponent - org.eclipse.kura.net.admin.NetworkConfigurationService....Done
Feb 09 10:38:08 dynagate-10-14 ESF[23999]: Activate NMStatusService...
Feb 09 10:38:08 dynagate-10-14 ESF[23999]: Activate NMStatusService... Done.
Feb 09 10:38:08 dynagate-10-14 ESF[23999]: Enabling interface 3-1.3 took 971 ms
```

PR37:

```
Feb 09 10:26:32 dynagate-10-14 ESF[15054]: Device "lo" of type "NM_DEVICE_TYPE_LOOPBACK" with status "UNMANAGED"/"UNMANAGED" currently not supported
Feb 09 10:26:32 dynagate-10-14 ESF[15054]: Settings iface "eth0":NM_DEVICE_TYPE_ETHERNET
Feb 09 10:26:33 dynagate-10-14 ESF[15054]: Enabling interface eth0 took 496 ms
Feb 09 10:26:33 dynagate-10-14 ESF[15054]: Settings iface "eth1":NM_DEVICE_TYPE_ETHERNET
Feb 09 10:26:33 dynagate-10-14 ESF[15054]: Enabling interface eth1 took 250 ms
Feb 09 10:26:33 dynagate-10-14 ESF[15054]: Settings iface "wlan0":NM_DEVICE_TYPE_WIFI
Feb 09 10:26:34 dynagate-10-14 ESF[15054]: Enabling interface wlan0 took 350 ms
Feb 09 10:26:34 dynagate-10-14 ESF[15054]: Device "p2p0" of type "NM_DEVICE_TYPE_WIFI" not configured. Disabling...
Feb 09 10:26:34 dynagate-10-14 ESF[15054]: Settings iface "3-1.3":NM_DEVICE_TYPE_MODEM
Feb 09 10:26:34 dynagate-10-14 ESF[15054]: Modem 3-1.3 activated. Starting monitoring task...
Feb 09 10:26:34 dynagate-10-14 ESF[15054]: Connection for modem 3-1.3 successful
Feb 09 10:26:35 dynagate-10-14 ESF[15054]: Enabling interface 3-1.3 took 394 ms
```

PR36:

```
Device "lo" of type "NM_DEVICE_TYPE_LOOPBACK" with status "UNMANAGED"/"UNMANAGED" currently not supported
Settings iface "eth0":NM_DEVICE_TYPE_ETHERNET
No changes in connection settings for device eth0
Enabling interface eth0 took 555 ms
Settings iface "eth1":NM_DEVICE_TYPE_ETHERNET
No changes in connection settings for device eth1
Enabling interface eth1 took 278 ms
Settings iface "wlan0":NM_DEVICE_TYPE_WIFI
No changes in connection settings for device wlan0
Enabling interface wlan0 took 494 ms
Device "p2p0" of type "NM_DEVICE_TYPE_WIFI" not configured. Disabling...
Settings iface "3-1.3":NM_DEVICE_TYPE_MODEM
No changes in connection settings for device 3-1.3
Modem 3-1.3 activated. Starting monitoring task...
Connection for modem 3-1.3 successful
Enabling interface 3-1.3 took 554 ms
```

</details>

|Interface|Develop (ms)|PR37 (ms)|PR36 (ms)|
|---|---|---|---|
|eth0|595|496|555|
|eth1|361|250|278|
|wlan0|451|350|494|
|3-1.3|971|394|554|
|Total|2,378|1,490|1,881|

|Interface|Change (Develop → PR37)|Change (Develop → PR36)|
|---|---|---|
|eth0|-99 ms (-17%)|-40 ms (-7%)|
|eth1|-111 ms (-31%)|-83 ms (-23%)|
|wlan0|-101 ms (-22%)|+43 ms (+10%)|
|3-1.3|-577 ms (-59%)|-417 ms (-43%)|
|Total|-888 ms (-37%)|-497 ms (-21%)|

Where:
- Develop: `develop` branch at 678b4f381a236725e589d740b3f668e2268d9eb2
- PR37: #37
- PR36: #36 (which includes #37)