### PR TITLE
feat(nm): prevent unnecessary network deactivation

### DIFF
--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -599,12 +599,22 @@ public class NMDbusConnector {
                     createdConnectionPath.getPath(), Connection.class);
             connection = Optional.of(createdConnection);
         }
-
+        
+        boolean isReapplySuccessful = false;
         try {
-            this.networkManager.activateConnection(connection.get(), device);
-            dsLock.waitForSignal();
+            device.Reapply(newConnectionSettings, null, null);
+            isReapplySuccessful = true;
         } catch (DBusExecutionException e) {
-            logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
+            logger.warn("Couldn't reapply settings to {} interface, caused by:", deviceId, e);
+        }
+
+        if(!isReapplySuccessful) {
+            try {
+                this.networkManager.activateConnection(connection.get(), device);
+                dsLock.waitForSignal();
+            } catch (DBusExecutionException e) {
+                logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
+            }
         }
 
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -58,6 +58,8 @@ import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.UInt64;
 import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.modemmanager1.Modem;
 import org.freedesktop.modemmanager1.modem.Location;
@@ -602,7 +604,7 @@ public class NMDbusConnector {
         
         boolean isReapplySuccessful = false;
         try {
-            device.Reapply(newConnectionSettings, null, null);
+            device.Reapply(newConnectionSettings, new UInt64(0), new UInt32(0));
             dsLock.waitForSignal();
             isReapplySuccessful = true;
         } catch (DBusExecutionException e) {

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -58,8 +58,6 @@ import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
-import org.freedesktop.dbus.types.UInt32;
-import org.freedesktop.dbus.types.UInt64;
 import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.modemmanager1.Modem;
 import org.freedesktop.modemmanager1.modem.Location;

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -603,6 +603,7 @@ public class NMDbusConnector {
         boolean isReapplySuccessful = false;
         try {
             device.Reapply(newConnectionSettings, null, null);
+            dsLock.waitForSignal();
             isReapplySuccessful = true;
         } catch (DBusExecutionException e) {
             logger.warn("Couldn't reapply settings to {} interface, caused by:", deviceId, e);

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -605,7 +605,6 @@ public class NMDbusConnector {
         boolean isReapplySuccessful = false;
         try {
             device.Reapply(newConnectionSettings, new UInt64(0), new UInt32(0));
-            dsLock.waitForSignal();
             isReapplySuccessful = true;
         } catch (DBusExecutionException e) {
             logger.warn("Couldn't reapply settings to {} interface, caused by:", deviceId, e);

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -602,13 +602,7 @@ public class NMDbusConnector {
             connection = Optional.of(createdConnection);
         }
         
-        boolean isReapplySuccessful = false;
-        try {
-            device.Reapply(newConnectionSettings, new UInt64(0), new UInt32(0));
-            isReapplySuccessful = true;
-        } catch (DBusExecutionException e) {
-            logger.warn("Couldn't reapply settings to {} interface, caused by:", deviceId, e);
-        }
+        boolean isReapplySuccessful = this.networkManager.reapplySettings(device, newConnectionSettings);
 
         if(!isReapplySuccessful) {
             try {

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -215,9 +215,8 @@ public class NetworkManagerDbusWrapper {
             device.Reapply(settings, new UInt64(0), new UInt32(0));
             return true;
         } catch (DBusExecutionException e) {
-            logger.error("Failed to reapply settings to device {}", device.getObjectPath(), e);
-        } catch (Exception e) {
-            logger.error("Unexpected error while reapplying settings to device {}", device.getObjectPath(), e);
+            logger.info("Could not reapply settings to device {}", device.getObjectPath());
+            logger.debug("Caused by", e);
         }
         return false;
     }

--- a/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/bundles/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -28,6 +28,7 @@ import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.UInt64;
 import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.networkmanager.Device;
 import org.freedesktop.networkmanager.Settings;
@@ -207,6 +208,18 @@ public class NetworkManagerDbusWrapper {
     protected void activateConnection(Connection connection, Device device) {
         this.networkManager.ActivateConnection(new DBusPath(connection.getObjectPath()),
                 new DBusPath(device.getObjectPath()), new DBusPath("/"));
+    }
+
+    protected boolean reapplySettings(Device device, Map<String, Map<String, Variant<?>>> settings) {
+        try {
+            device.Reapply(settings, new UInt64(0), new UInt32(0));
+            return true;
+        } catch (DBusExecutionException e) {
+            logger.error("Failed to reapply settings to device {}", device.getObjectPath(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error while reapplying settings to device {}", device.getObjectPath(), e);
+        }
+        return false;
     }
 
     protected List<Properties> getAllAccessPoints(Wireless wirelessDevice) throws DBusException {

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -448,6 +448,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("eth0");
+        thenReapplyIsCalledFor("eth0");
         thenActivateConnectionIsCalledFor("eth0");
     }
 
@@ -677,6 +678,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
+        thenReapplyIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
         thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
     }
@@ -703,6 +705,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
+        thenReapplyIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
         thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
         thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED),
@@ -732,6 +735,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
+        thenReapplyIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
         thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
         thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED),
@@ -761,6 +765,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
+        thenReapplyIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
         thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
         thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW,
@@ -788,6 +793,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
+        thenReapplyIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
         thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
     }
@@ -957,6 +963,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("eth0");
+        thenReapplyIsCalledFor("eth0");
         thenActivateConnectionIsCalledFor("eth0");
         thenConfigurationEnforcementIsActive(true);
     }
@@ -984,6 +991,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("eth0");
+        thenReapplyIsCalledFor("eth0");
         thenActivateConnectionIsCalledFor("eth0");
         thenConfigurationEnforcementIsActive(true);
     }
@@ -1160,6 +1168,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("wlan0");
+        thenReapplyIsCalledFor("wlan0");
         thenActivateConnectionIsCalledFor("wlan0");
     }
 
@@ -1178,6 +1187,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsNotCalledFor("wlan0");
+        thenReapplyIsNotCalledFor("wlan0");
         thenActivateConnectionIsNotCalledFor("wlan0");
     }
 
@@ -1196,6 +1206,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("wlan0");
+        thenReapplyIsCalledFor("wlan0");
         thenActivateConnectionIsCalledFor("wlan0");
     }
 
@@ -1214,6 +1225,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsNotCalledFor("wlan0");
+        thenReapplyIsNotCalledFor("wlan0");
         thenActivateConnectionIsNotCalledFor("wlan0");
     }
 
@@ -1280,6 +1292,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
+        thenReapplyIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
         thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
     }
@@ -1911,6 +1924,10 @@ public class NMDbusConnectorTest {
 
     private void thenReapplyIsCalledFor(String netInterface) throws DBusException {
         verify(this.mockDevices.get(netInterface)).Reapply(any(), any(), any());
+    }
+
+    private void thenReapplyIsNotCalledFor(String netInterface) throws DBusException {
+        verify(this.mockDevices.get(netInterface), never()).Reapply(any(), any(), any());
     }
 
     private void thenActivateConnectionIsNotCalledFor(String netInterface) throws DBusException {

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -329,10 +329,8 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplyIsCalledWith(null);
@@ -345,10 +343,8 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplyIsCalledWith(new HashMap<String, Object>());
@@ -363,10 +359,8 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplySingleIsCalledWith("eth1");
@@ -381,10 +375,8 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplySingleIsCalledWith(null);
@@ -397,10 +389,8 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplySingleIsCalledWith("");
@@ -413,7 +403,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("unused0", "unused0", NMDeviceType.NM_DEVICE_TYPE_UNUSED1,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("unused0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "unused0");
@@ -491,6 +480,7 @@ public class NMDbusConnectorTest {
         whenApplyIsCalledWith(this.netConfig);
 
         thenNoExceptionIsThrown();
+        thenReapplyIsCalledFor("eth0");
         thenAddAndActivateConnectionIsCalledFor("eth0");
     }
 
@@ -499,7 +489,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth,");
@@ -516,7 +505,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, false, false, false);
-        givenSettingsReapplyFailsFor("eth0");
         /*
          * givenMockedDevice("myVlan", "myVlan", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
          * NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, false, false, false);
@@ -553,7 +541,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, false, false, false);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("myVlan", "myVlan", NMDeviceType.NM_DEVICE_TYPE_VLAN, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
         givenMockedDeviceList();
@@ -582,7 +569,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("lo", "lo", NMDeviceType.NM_DEVICE_TYPE_LOOPBACK, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("lo");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "lo,");
@@ -599,7 +585,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("lo", "lo", NMDeviceType.NM_DEVICE_TYPE_GENERIC, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("lo");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "lo,");
@@ -616,7 +601,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -636,7 +620,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -677,6 +660,33 @@ public class NMDbusConnectorTest {
         thenConnectionUpdateIsCalledFor("ttyACM17");
         thenReapplyIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
+    }
+
+    @Test
+    public void applyShouldWorkWithEnabledModemWhenReapplySucceeds() throws DBusException, IOException {
+        givenBasicMockedDbusConnector();
+        givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
+                true, false, false);
+        // Reapply will succeed by default
+        givenMockedDeviceList();
+
+        givenNetworkConfigMapWith("net.interfaces", "1-5,");
+        givenNetworkConfigMapWith("net.interface.1-5.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
+        givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
+        givenNetworkConfigMapWith("net.interface.1-5.config.gpsEnabled", false);
+        givenNetworkConfigMapWith("net.interface.1-5.config.resetTimeout", 0);
+        givenNetworkConfigMapWith("net.interface.1-5.config.persist", false);
+        givenNetworkConfigMapWith("net.interface.1-5.config.holdoff", 15);
+        givenNetworkConfigMapWith("net.interface.1-5.config.maxFail", 3);
+
+        whenApplyIsCalledWith(this.netConfig);
+
+        thenNoExceptionIsThrown();
+        thenConnectionUpdateIsCalledFor("ttyACM17");
+        thenReapplyIsCalledFor("ttyACM17");
+        thenActivateConnectionIsNotCalledFor("ttyACM17");
         thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
     }
 
@@ -914,7 +924,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, true, true);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
@@ -959,6 +968,34 @@ public class NMDbusConnectorTest {
     }
 
     @Test
+    public void configurationEnforcementShouldUseReapplyWithExternalChangeSignal() throws DBusException, IOException {
+        givenBasicMockedDbusConnector();
+        givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
+                NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, true, true);
+        // Reapply will succeed by default
+        givenMockedDeviceList();
+
+        givenNetworkConfigMapWith("net.interfaces", "eth0");
+        givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+
+        givenApplyWasCalledOnceWith(this.netConfig);
+
+        whenDeviceStateChangeSignalAppearsWith("/mock/device/eth0",
+                NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED),
+                NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_CONFIG), new UInt32(1));
+
+        thenNoExceptionIsThrown();
+        thenConnectionUpdateIsCalledFor("eth0");
+        thenReapplyIsCalledFor("eth0");
+        thenActivateConnectionIsNotCalledFor("eth0");
+        thenConfigurationEnforcementIsActive(true);
+    }
+
+    @Test
     public void configurationEnforcementShouldTriggerWithExternalDisconnect() throws DBusException, IOException {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
@@ -991,7 +1028,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, true, true);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
@@ -1018,7 +1054,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth1", "eth1", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("eth1");
         givenMockedDeviceList();
 
         givenMockedAssociatedConnection("kura-eth1-connection", "uuid-1234", "eth1", "/connection/path/mock/0");
@@ -1048,7 +1083,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth1", "eth1", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("eth1");
         givenMockedDeviceList();
 
         givenMockedConnection("kura-eth1-connection", "uuid-1234", "wlan0", "/connection/path/mock/1");
@@ -1076,7 +1110,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         givenMockedConnection("kura-wlan0-connection", "uuid-1234", "wlan0", "/connection/path/mock/1");
@@ -1103,7 +1136,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         givenMockedAssociatedConnection("kura-wlan0-connection", "uuid-1234", "wlan0", "/connection/path/mock/0");
@@ -1166,7 +1198,6 @@ public class NMDbusConnectorTest {
         givenSystemService(false, 30);
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         givenWifiInterfaceConfiguration("SECURITY_WPA3");
@@ -1204,7 +1235,6 @@ public class NMDbusConnectorTest {
         givenSystemService(false, 30);
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         givenWifiInterfaceConfiguration("SECURITY_WPA2_WPA3");
@@ -1222,7 +1252,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eno1", "eno1", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("eno1");
         givenMockedDeviceList();
         givenNetworkConfigMapWith("net.interfaces", "eno1");
         givenNetworkConfigMapWith("net.interface.1-6.config.dhcpClient4.enabled", true);
@@ -1240,7 +1269,6 @@ public class NMDbusConnectorTest {
         givenNMActivationFailed();
         givenMockedDevice("1-6", "wwan0", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true,
                 false, false);
-        givenSettingsReapplyFailsFor("wwan0");
         givenMockedDeviceList();
         givenNetworkConfigMapWith("net.interfaces", "1-6");
         givenNetworkConfigMapWith("net.interface.1-6.config.resetTimeout", 2);
@@ -1257,12 +1285,12 @@ public class NMDbusConnectorTest {
     }
 
     @Test
-    public void shouldStartModemTaskHandlerEvenIfReapplySucceeds() throws DBusException, IOException {
+    public void shouldStartModemTaskHandlerEvenIfReapplyFails() throws DBusException, IOException {
         givenBasicMockedDbusConnector();
         givenNMActivationFailed();
         givenMockedDevice("1-6", "wwan0", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true,
                 false, false);
-        // Reapply will succeed by default
+        givenSettingsReapplyFailsFor("wwan0");
         givenMockedDeviceList();
         givenNetworkConfigMapWith("net.interfaces", "1-6");
         givenNetworkConfigMapWith("net.interface.1-6.config.resetTimeout", 2);
@@ -1957,6 +1985,7 @@ public class NMDbusConnectorTest {
     private void thenNetworkSettingsDidNotChangeForDevice(String netInterface) throws DBusException {
         verify(this.mockConnection, never()).Update(any());
         verify(this.mockDevices.get(netInterface), never()).Disconnect();
+        verify(this.mockDevices.get(netInterface), never()).Reapply(any(), any(), any());
         verify(this.mockedNetworkManager, never()).ActivateConnection(any(), any(), any());
         verify(this.mockedNetworkManager, never()).AddAndActivateConnection(any(), any(), any());
     }

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -616,7 +616,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("1-5");
+        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -685,7 +685,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("1-5");
+        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -714,7 +714,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("1-5");
+        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -744,7 +744,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("1-5");
+        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -870,7 +870,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED,
                 true, false, true);
-        givenSettingsReapplyFailsFor("1-5");
+        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("1-5", this.commandExecutorService);

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1257,6 +1257,28 @@ public class NMDbusConnectorTest {
     }
 
     @Test
+    public void shouldStartModemTaskHandlerEvenIfReapplySucceeds() throws DBusException, IOException {
+        givenBasicMockedDbusConnector();
+        givenNMActivationFailed();
+        givenMockedDevice("1-6", "wwan0", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true,
+                false, false);
+        // Reapply will succeed by default
+        givenMockedDeviceList();
+        givenNetworkConfigMapWith("net.interfaces", "1-6");
+        givenNetworkConfigMapWith("net.interface.1-6.config.resetTimeout", 2);
+        givenNetworkConfigMapWith("net.interface.1-6.config.dhcpClient4.enabled", true);
+        givenNetworkConfigMapWith("net.interface.1-6.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenNetworkConfigMapWith("net.interface.1-6.config.persist", true);
+        givenNetworkConfigMapWith("net.interface.1-6.config.holdoff", 15);
+        givenNetworkConfigMapWith("net.interface.1-6.config.maxFail", 3);
+
+        whenApplyIsCalledWith(this.netConfig);
+
+        thenNoExceptionIsThrown();
+        thenModemTaskHandlerIsActive(true, "1-6");
+    }
+
+    @Test
     public void asyncApplyShouldWorkWithEnabledModem() throws DBusException, IOException {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -294,10 +294,13 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDevice("eth0.10", "eth0.10", NMDeviceType.NM_DEVICE_TYPE_VLAN,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("eth0.10");
         givenMockedDeviceList();
 
         whenGetInterfaceIdsIsCalled();
@@ -311,8 +314,10 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplyIsCalled();
@@ -327,8 +332,10 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplyIsCalledWith(null);
@@ -341,8 +348,10 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplyIsCalledWith(new HashMap<String, Object>());
@@ -357,8 +366,10 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplySingleIsCalledWith("eth1");
@@ -373,8 +384,10 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplySingleIsCalledWith(null);
@@ -387,8 +400,10 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenApplySingleIsCalledWith("");
@@ -401,6 +416,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("unused0", "unused0", NMDeviceType.NM_DEVICE_TYPE_UNUSED1,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("unused0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "unused0");
@@ -418,6 +434,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
@@ -438,7 +455,8 @@ public class NMDbusConnectorTest {
     public void activateShouldNotBeCalledWhenReapplySucceeds() throws DBusException, IOException {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
-                NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false, true);
+                NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
+        // Reapply will succeed by default
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
@@ -461,6 +479,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, false, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
         givenMockToPrepNetworkManagerToAllowDeviceToCreateNewConnection();
 
@@ -482,6 +501,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth,");
@@ -498,9 +518,11 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, false, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         /*
          * givenMockedDevice("myVlan", "myVlan", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
          * NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, false, false, false);
+         * givenSettingsReapplyFailsFor("myVlan");
          */
         givenMockedDeviceList();
 
@@ -533,8 +555,9 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, false, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("myVlan", "myVlan", NMDeviceType.NM_DEVICE_TYPE_VLAN, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
-                true, false, false);//
+                true, false, false);
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0,myVlan");
@@ -561,6 +584,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("lo", "lo", NMDeviceType.NM_DEVICE_TYPE_LOOPBACK, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("lo");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "lo,");
@@ -577,6 +601,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("lo", "lo", NMDeviceType.NM_DEVICE_TYPE_GENERIC, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("lo");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "lo,");
@@ -593,6 +618,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -612,6 +638,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -633,6 +660,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -658,6 +686,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -685,6 +714,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -713,6 +743,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -741,6 +772,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -765,6 +797,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("eth0", this.commandExecutorService);
@@ -779,6 +812,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("lo", "lo", NMDeviceType.NM_DEVICE_TYPE_LOOPBACK, NMDeviceState.NM_DEVICE_STATE_FAILED, true,
                 false, false);
+        givenSettingsReapplyFailsFor("lo");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("lo", this.commandExecutorService);
@@ -793,6 +827,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("unused0", "unused0", NMDeviceType.NM_DEVICE_TYPE_UNUSED1,
                 NMDeviceState.NM_DEVICE_STATE_FAILED, true, false, false);
+        givenSettingsReapplyFailsFor("unused0");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("unused0", this.commandExecutorService);
@@ -806,6 +841,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_FAILED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("wlan0", this.commandExecutorService);
@@ -820,6 +856,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED,
                 true, true, true);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("1-5", this.commandExecutorService);
@@ -835,6 +872,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED,
                 true, false, true);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("1-5", this.commandExecutorService);
@@ -850,6 +888,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED,
                 true, true, false);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("1-5", this.commandExecutorService);
@@ -866,6 +905,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, true, true);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         thenNoExceptionIsThrown();
@@ -878,6 +918,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, true, true);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
@@ -898,6 +939,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, true, true);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
@@ -924,6 +966,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, true, true);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
@@ -950,6 +993,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, true, true);
+        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
@@ -976,6 +1020,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth1", "eth1", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("eth1");
         givenMockedDeviceList();
 
         givenMockedAssociatedConnection("kura-eth1-connection", "uuid-1234", "eth1", "/connection/path/mock/0");
@@ -1005,6 +1050,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth1", "eth1", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("eth1");
         givenMockedDeviceList();
 
         givenMockedConnection("kura-eth1-connection", "uuid-1234", "wlan0", "/connection/path/mock/1");
@@ -1032,6 +1078,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         givenMockedConnection("kura-wlan0-connection", "uuid-1234", "wlan0", "/connection/path/mock/1");
@@ -1058,6 +1105,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         givenMockedAssociatedConnection("kura-wlan0-connection", "uuid-1234", "wlan0", "/connection/path/mock/0");
@@ -1086,6 +1134,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenGetInterfaceStatusWithRecompute("wlan0", this.commandExecutorService);
@@ -1102,6 +1151,7 @@ public class NMDbusConnectorTest {
         givenSystemService(true, 30);
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         givenWifiInterfaceConfiguration("SECURITY_WPA3");
@@ -1119,6 +1169,7 @@ public class NMDbusConnectorTest {
         givenSystemService(false, 30);
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         givenWifiInterfaceConfiguration("SECURITY_WPA3");
@@ -1136,6 +1187,7 @@ public class NMDbusConnectorTest {
         givenSystemService(true, 30);
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         givenWifiInterfaceConfiguration("SECURITY_WPA2_WPA3");
@@ -1153,6 +1205,7 @@ public class NMDbusConnectorTest {
         givenSystemService(false, 30);
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         givenWifiInterfaceConfiguration("SECURITY_WPA2_WPA3");
@@ -1169,6 +1222,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eno1", "eno1", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("eno1");
         givenMockedDeviceList();
         givenNetworkConfigMapWith("net.interfaces", "eno1");
         givenNetworkConfigMapWith("net.interface.1-6.config.dhcpClient4.enabled", true);
@@ -1186,6 +1240,7 @@ public class NMDbusConnectorTest {
         givenNMActivationFailed();
         givenMockedDevice("1-6", "wwan0", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true,
                 false, false);
+        givenSettingsReapplyFailsFor("1-6");
         givenMockedDeviceList();
         givenNetworkConfigMapWith("net.interfaces", "1-6");
         givenNetworkConfigMapWith("net.interface.1-6.config.resetTimeout", 2);
@@ -1206,6 +1261,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
+        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
         givenSystemService(false, 10);
 
@@ -1376,6 +1432,11 @@ public class NMDbusConnectorTest {
             givenModemMocksFor(deviceId, interfaceId, mockedProperties, hasBearers, hasSims);
         }
 
+    }
+
+    public void givenSettingsReapplyFailsFor(String interfaceId) {
+        doThrow(new DBusExecutionException("Reapply Configuration Failed!"))
+                    .when(this.mockDevices.get(interfaceId)).Reapply(any(), any(), any());
     }
 
     public void givenMockToPrepNetworkManagerToAllowDeviceToCreateNewConnection() throws DBusException {

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -435,6 +435,28 @@ public class NMDbusConnectorTest {
     }
 
     @Test
+    public void activateShouldNotBeCalledWhenReapplySucceeds() throws DBusException, IOException {
+        givenBasicMockedDbusConnector();
+        givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
+                NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false, true);
+        givenMockedDeviceList();
+
+        givenNetworkConfigMapWith("net.interfaces", "eth0");
+        givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+
+        whenApplyIsCalledWith(this.netConfig);
+
+        thenNoExceptionIsThrown();
+        thenConnectionUpdateIsCalledFor("eth0");
+        thenReapplyIsCalledFor("eth0");
+        thenActivateConnectionIsNotCalledFor("eth0");
+    }
+
+    @Test
     public void applyShouldWorkWithEnabledEthernetWithoutInitialConnection() throws DBusException, IOException {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
@@ -1824,6 +1846,10 @@ public class NMDbusConnectorTest {
 
     private void thenActivateConnectionIsCalledFor(String netInterface) throws DBusException {
         verify(this.mockedNetworkManager).ActivateConnection(any(), any(), any());
+    }
+
+    private void thenReapplyIsCalledFor(String netInterface) throws DBusException {
+        verify(this.mockDevices.get(netInterface)).Reapply(any(), any(), any());
     }
 
     private void thenActivateConnectionIsNotCalledFor(String netInterface) throws DBusException {

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1240,7 +1240,7 @@ public class NMDbusConnectorTest {
         givenNMActivationFailed();
         givenMockedDevice("1-6", "wwan0", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true,
                 false, false);
-        givenSettingsReapplyFailsFor("1-6");
+        givenSettingsReapplyFailsFor("wwan0");
         givenMockedDeviceList();
         givenNetworkConfigMapWith("net.interfaces", "1-6");
         givenNetworkConfigMapWith("net.interface.1-6.config.resetTimeout", 2);
@@ -1261,7 +1261,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("1-5");
+        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
         givenSystemService(false, 10);
 

--- a/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/tests/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -294,13 +294,10 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDevice("eth0.10", "eth0.10", NMDeviceType.NM_DEVICE_TYPE_VLAN,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
-        givenSettingsReapplyFailsFor("eth0.10");
         givenMockedDeviceList();
 
         whenGetInterfaceIdsIsCalled();
@@ -639,7 +636,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("1-5");
+        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -661,7 +658,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("1-5");
+        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -777,7 +774,7 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("1-5");
+        givenSettingsReapplyFailsFor("ttyACM17");
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
@@ -803,7 +800,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("eth0", this.commandExecutorService);
@@ -818,7 +814,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("lo", "lo", NMDeviceType.NM_DEVICE_TYPE_LOOPBACK, NMDeviceState.NM_DEVICE_STATE_FAILED, true,
                 false, false);
-        givenSettingsReapplyFailsFor("lo");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("lo", this.commandExecutorService);
@@ -833,7 +828,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("unused0", "unused0", NMDeviceType.NM_DEVICE_TYPE_UNUSED1,
                 NMDeviceState.NM_DEVICE_STATE_FAILED, true, false, false);
-        givenSettingsReapplyFailsFor("unused0");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("unused0", this.commandExecutorService);
@@ -847,7 +841,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_FAILED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("wlan0", this.commandExecutorService);
@@ -862,7 +855,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED,
                 true, true, true);
-        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("1-5", this.commandExecutorService);
@@ -894,7 +886,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED,
                 true, true, false);
-        givenSettingsReapplyFailsFor("1-5");
         givenMockedDeviceList();
 
         whenGetInterfaceStatus("1-5", this.commandExecutorService);
@@ -911,7 +902,6 @@ public class NMDbusConnectorTest {
         givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET,
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, true, true);
-        givenSettingsReapplyFailsFor("eth0");
         givenMockedDeviceList();
 
         thenNoExceptionIsThrown();
@@ -1138,11 +1128,9 @@ public class NMDbusConnectorTest {
 
     @Test
     public void shouldTriggerWirelessNetworkScan() throws DBusException, IOException {
-
         givenBasicMockedDbusConnector();
         givenMockedDevice("wlan0", "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
                 true, false, false);
-        givenSettingsReapplyFailsFor("wlan0");
         givenMockedDeviceList();
 
         whenGetInterfaceStatusWithRecompute("wlan0", this.commandExecutorService);
@@ -1703,6 +1691,7 @@ public class NMDbusConnectorTest {
         clearInvocations(this.mockedNetworkManager);
         clearInvocations(this.dbusConnection);
         clearInvocations(this.mockConnection);
+        clearInvocations(this.mockDevices.values().toArray());
     }
 
     private void givenSystemService(boolean isWPASupported, int configurationTimeout) {


### PR DESCRIPTION
This PR attempts to reduce the number of unnecessary network configuration updates and interface deactivations by leveraging the `Device.Reapply` DBus method.

**Unnecessary rewrites**: Please note that this change doesn't prevent unnecessary configuration rewrites (i.e. `/etc/NetworkManager/system-connection` files udpates). Configuration rewrites are handled by [`Connection.Update()`](https://networkmanager.dev/docs/api/latest/gdbus-org.freedesktop.NetworkManager.Settings.Connection.html#gdbus-method-org-freedesktop-NetworkManager-Settings-Connection.Update) method which we call every time the "Apply" button is pressed on the WebUI. To avoid unnecessary rewrites we would need to compare the current settings with the new ones (see #36 where we attempted to do that).

**Signal wait**: contrary to [`NetworkManager.ActivateConnection`](https://networkmanager.dev/docs/api/latest/gdbus-org.freedesktop.NetworkManager.html#gdbus-method-org-freedesktop-NetworkManager.ActivateConnection) we used before, `Device.Reapply` doesn't seem to trigger state changes (and therefore no related DBus Signal) that might trip our Configuration Enforcement mechanism. Therefore I didn't add any `waitForSignal()` statement.

---

Test scenario:
- Starting with `eth1` device set with IP `192.168.1.24`
- Via Kura UI `eth1` configuration is updated to use DHCP

Before this PR:

```
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.8449] audit: op="connection-update" uuid="80d624f4-1645-46da-9427-89e6d758f013" name="kura-eth1-connection" args="connection.timestamp,ipv4.addresses,ipv4.gateway,ipv4.method" pid=27048 uid=995 result="success"
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.8903] device (eth1): state change: activated -> deactivating (reason 'new-activation', sys-iface-state: 'managed')
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.8910] manager: NetworkManager state is now CONNECTING
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.8931] device (eth1): disconnecting for new activation request.
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.8934] audit: op="connection-activate" uuid="80d624f4-1645-46da-9427-89e6d758f013" name="kura-eth1-connection" pid=27048 uid=995 result="success"
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.9071] device (eth1): state change: deactivating -> disconnected (reason 'new-activation', sys-iface-state: 'managed')
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.9562] manager: NetworkManager state is now CONNECTED_GLOBAL
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.9564] policy: set 'kura-eth0-connection' (eth0) as default for IPv4 routing and DNS
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.9677] device (eth1): Activation: starting connection 'kura-eth1-connection' (80d624f4-1645-46da-9427-89e6d758f013)
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.9697] device (eth1): state change: disconnected -> prepare (reason 'none', sys-iface-state: 'managed')
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.9708] device (eth1): state change: prepare -> config (reason 'none', sys-iface-state: 'managed')
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.9761] manager: NetworkManager state is now CONNECTING
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.9797] device (eth1): state change: config -> ip-config (reason 'none', sys-iface-state: 'managed')
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.9804] dhcp4 (eth1): activation: beginning transaction (timeout in 45 seconds)
Feb 03 14:01:14 raspberrypi NetworkManager[567]: <info>  [1770123674.9929] dhcp4 (eth1): dhclient started with pid 33656
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.0150] manager: NetworkManager state is now CONNECTED_GLOBAL
Feb 03 14:01:15 raspberrypi dhclient[33656]: DHCPREQUEST for 192.168.1.117 on eth1 to 255.255.255.255 port 67
Feb 03 14:01:15 raspberrypi dhclient[33656]: DHCPACK of 192.168.1.117 from 192.168.1.1
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.0950] dhcp4 (eth1):   address 192.168.1.117
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.0951] dhcp4 (eth1):   plen 24 (255.255.255.0)
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.0952] dhcp4 (eth1):   gateway 192.168.1.1
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.0952] dhcp4 (eth1):   lease time 86400
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.0952] dhcp4 (eth1):   hostname 'raspberrypi'
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.0952] dhcp4 (eth1):   nameserver '192.168.1.10'
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.0953] dhcp4 (eth1):   domain name 'localdomain'
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.0953] dhcp4 (eth1): state changed new lease, address=192.168.1.117
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.1264] device (eth1): state change: ip-config -> ip-check (reason 'none', sys-iface-state: 'managed')
Feb 03 14:01:15 raspberrypi dhclient[33656]: bound to 192.168.1.117 -- renewal in 35655 seconds.
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.1368] device (eth1): state change: ip-check -> secondaries (reason 'none', sys-iface-state: 'managed')
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.1446] device (eth1): state change: secondaries -> activated (reason 'none', sys-iface-state: 'managed')
Feb 03 14:01:15 raspberrypi NetworkManager[567]: <info>  [1770123675.1479] device (eth1): Activation: successful, device activated.
```

After this PR:

```
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.4239] audit: op="connection-update" uuid="80d624f4-1645-46da-9427-89e6d758f013" name="kura-eth1-connection" args="ipv4.addresses,ipv4.gateway,ipv4.method" pid=19476 uid=995 result="success"
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.4620] audit: op="device-reapply" interface="eth1" ifindex=6 args="ipv4.addresses,ipv4.gateway,ipv4.method" pid=19476 uid=995 result="success"
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.4626] dhcp4 (eth1): activation: beginning transaction (timeout in 45 seconds)
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.4735] dhcp4 (eth1): dhclient started with pid 26897
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <warn>  [1770123412.5481] dispatcher: (52) /etc/NetworkManager/dispatcher.d/01-ifupdown failed (failed): Script '/etc/NetworkManager/dispatcher.d/01-ifupdown' exited with status 1.
Feb 03 13:56:52 raspberrypi dhclient[26897]: DHCPREQUEST for 192.168.1.117 on eth1 to 255.255.255.255 port 67
Feb 03 13:56:52 raspberrypi dhclient[26897]: DHCPACK of 192.168.1.117 from 192.168.1.1
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.5823] dhcp4 (eth1):   address 192.168.1.117
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.5824] dhcp4 (eth1):   plen 24 (255.255.255.0)
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.5824] dhcp4 (eth1):   gateway 192.168.1.1
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.5825] dhcp4 (eth1):   lease time 86400
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.5825] dhcp4 (eth1):   hostname 'raspberrypi'
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.5825] dhcp4 (eth1):   nameserver '192.168.1.10'
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.5825] dhcp4 (eth1):   domain name 'localdomain'
Feb 03 13:56:52 raspberrypi NetworkManager[567]: <info>  [1770123412.5826] dhcp4 (eth1): state changed new lease, address=192.168.1.117
Feb 03 13:56:52 raspberrypi dhclient[26897]: bound to 192.168.1.117 -- renewal in 40716 seconds.
```

References:
- https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1864#note_3283934
- https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/main/examples/python/gi/device-reapply.py?ref_type=heads

`Reapply` method documentation:
- https://networkmanager.dev/docs/api/latest/gdbus-org.freedesktop.NetworkManager.Device.html#gdbus-method-org-freedesktop-NetworkManager-Device.Reapply

> Attempts to update the configuration of a device without deactivating it. NetworkManager has the concept of connections, which are profiles that contain the configuration for a networking device. Those connections are exposed via D-Bus as individual objects that can be created, modified and deleted. When activating such a settings-connection on a device, the settings-connection is cloned to become an applied-connection and used to configure the device (see GetAppliedConnection). Subsequent modification of the settings-connection don't propagate automatically to the device's applied-connection (with exception of the firewall-zone and the metered property). For the changes to take effect, you can either re-activate the settings-connection, or call Reapply. The Reapply call allows you to directly update the applied-connection and reconfigure the device. Reapply can also be useful if the currently applied-connection is equal to the connection that is about to be reapplied. This allows one to reconfigure the device and revert external changes like removing or adding an IP address (which NetworkManager doesn't revert automatically because it is assumed that the user made these changes intentionally outside of NetworkManager). Reapply can make the applied-connection different from the settings-connection, just like updating the settings-connection can make them different.
>
>Since 1.42, "preserve-external-ip" flag (0x1) is supported to not remove externally added IP addresses and routes on the device during reapply.

`NMDeviceReapplyFlags`:
- https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/main/src/libnm-core-public/nm-dbus-interface.h#L1233