### PR TITLE
build: skipping bundles pom generation in tycho-packaging-plugin


### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tycho-version>4.0.13</tycho-version>
+        <tycho-version>5.0.2</tycho-version>
         <bnd-version>7.1.0</bnd-version>
         <maven.jarsigner.plugin.version>1.4</maven.jarsigner.plugin.version>
         <skip.artifact.signing>true</skip.artifact.signing>
@@ -106,8 +106,7 @@
                     <artifactId>tycho-packaging-plugin</artifactId>
                     <version>${tycho-version}</version>
                     <configuration>
-                        <strictVersions>true</strictVersions>
-                        <deriveHeaderFromSource>false</deriveHeaderFromSource>
+                        <skipPomGeneration>true</skipPomGeneration>
                     </configuration>
                 </plugin>
 

--- a/target-definition/kura-networking.target
+++ b/target-definition/kura-networking.target
@@ -35,7 +35,6 @@
                     <groupId>org.eclipse.kura</groupId>
                     <artifactId>org.eclipse.kura.linux.position</artifactId>
                     <version>2.0.0-SNAPSHOT</version>
-                    <type>jar</type>
                 </dependency>
             </dependencies>
 


### PR DESCRIPTION
Deployed artifacts contain wrong path autogenerated by the tycho-packaging-plugin, preventing correct build in other bundles. This PR fixes the problem