### PR TITLE
build: removed parent from bundles pom

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -19,13 +19,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.eclipse.kura</groupId>
-        <artifactId>kura-networking</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
-    </parent>
-
+    <groupId>org.eclipse.kura</groupId>
     <artifactId>kura-networking.parent</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Parent POM for kura-networking</name>
@@ -63,7 +59,7 @@
                         <requireJREPackageImports>true</requireJREPackageImports>
                     </configuration>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
Wrong parent in bundle pom leads to unresolved dependencies in those bundles that import kura-networking bundles